### PR TITLE
Shrinking image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,37 @@
 FROM ubuntu:16.04
-MAINTAINER Shuanglei Tao "tsl0922@gmail.com"
+LABEL maintainer "Shuanglei Tao - tsl0922@gmail.com"
 
-RUN apt-get update && \
-    apt-get install -y cmake g++ pkg-config git vim-common libwebsockets-dev libjson-c-dev libssl-dev && \
-    rm -rf /var/lib/apt/lists/* && \
-    git clone --depth=1 https://github.com/tsl0922/ttyd.git /tmp/ttyd && \
-    cd /tmp/ttyd && mkdir build && cd build && \
-    cmake .. && make && make install && \
-    rm -rf /tmp/ttyd
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      cmake \
+      curl \
+      g++ \
+      git \
+      libjson-c2 \
+      libjson-c-dev \
+      libssl1.0.0 \
+      libssl-dev \
+      libwebsockets7 \
+      libwebsockets-dev \
+      pkg-config \
+      vim-common \
+    && git clone --depth=1 https://github.com/tsl0922/ttyd.git /tmp/ttyd \
+    && cd /tmp/ttyd && mkdir build && cd build \
+    && cmake .. \
+    && make \
+    && make install \
+    && apt-get remove -y --purge \
+        cmake \
+        g++ \
+        libwebsockets-dev \
+        libjson-c-dev \
+        libssl-dev \
+        pkg-config \
+    && apt-get purge -y \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/ttyd
 
 EXPOSE 7681
 


### PR DESCRIPTION
Signed-off-by: Damien DUPORTAL <damien.duportal@gmail.com>

Hello !

This Pull Request is about the ttyd docker image. My goal was to shrink up the image size, given I was needed to free some space on my context.

On my Docker4Mac 1.13.0, the virtual image size reported by docker went from 482 Mb to 208 Mb:
```
$ docker build -t ttyd:latest ./
(... build log ...)
$ docker images | grep tty
ttyd            latest    20a69e0c3878    29 minutes ago    208 MB
tsl0922/ttyd    latest    f6566ed4599b    6 days ago        482 MB
```

Here are the PR actions:

- Replacing `MAINTAINER` by `LABEL` (since it is deprecated with Docker 1.13)
- Removing the `*-dev` and all building libs at the end (we don't need cmake when running ttyd for example) 
- Enforcing the ending cleaning by auto purging the installed libs
- Adding `libjson-c2`, `libssl1.0.0` and `libwebsockets7` as explicit dependencies for the runtime: thus they are not purged at the end, and stay to be used by ttyd app
- Adding ca-certificates and curl to validate SSL certificates


I've only done a local "smoke" test: aka. I can run this image of 208 Mb, with a port forwarding, and ttyd works well on my local Chrome.

If you want me to run more testing of the docker images, I can help.

WDYT ?
