### PR TITLE
Introduce Alpine Docker build

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -25,7 +25,7 @@ RUN apk add --update --no-cache \
     && curl -LO \
         "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk" \
     && apk add --no-cache "glibc-${GLIBC_VERSION}.apk" \
-    && git clone -b "v${LIBWEBSOCKETS_VERSION}" https://github.com/warmcat/libwebsockets.git \
+    && git clone --depth=1 -b "v${LIBWEBSOCKETS_VERSION}" https://github.com/warmcat/libwebsockets.git \
         /tmp/libwebsockets \
     && git clone --depth=1 -b "${TTYD_VERSION}" https://github.com/tsl0922/ttyd.git \
         /tmp/ttyd \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,0 +1,48 @@
+FROM alpine:3.5
+LABEL maintainer "Shuanglei Tao - tsl0922@gmail.com" \
+    maintainer "Damien Duportal - damien.duportal@gmail.com"
+
+ENV GLIBC_VERSION=2.25-r0 \
+    LIBWEBSOCKETS_VERSION=2.1.1 \
+    TTYD_VERSION=1.3.0
+
+RUN apk add --update --no-cache \
+        bash \
+        bsd-compat-headers \
+        build-base \
+        ca-certificates \
+        cmake \
+        curl \
+        git \
+        g++ \
+        json-c \
+        json-c-dev \
+        openssl \
+        openssl-dev \
+        vim \
+    && curl -L -o /etc/apk/keys/sgerrand.rsa.pub \
+        https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub \
+    && curl -LO \
+        "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk" \
+    && apk add --no-cache "glibc-${GLIBC_VERSION}.apk" \
+    && git clone -b "v${LIBWEBSOCKETS_VERSION}" https://github.com/warmcat/libwebsockets.git \
+        /tmp/libwebsockets \
+    && git clone --depth=1 -b "${TTYD_VERSION}" https://github.com/tsl0922/ttyd.git \
+        /tmp/ttyd \
+    && mkdir -p /tmp/ttyd/build /tmp/libwebsockets/build \
+    && cd /tmp/libwebsockets/build \
+    && cmake .. \
+    && make \
+    && make install \
+    && cd /tmp/ttyd/build \
+    && cmake .. \
+    && make \
+    && make install \
+    && rm -rf /tmp/* /var/cache/apk/* /*.apk \
+    && apk del --purge build-base openssl-dev json-c-dev g++ cmake bsd-compat-headers
+
+EXPOSE 7681
+
+ENTRYPOINT ["ttyd"]
+
+CMD ["bash"]


### PR DESCRIPTION
Signed-off-by: Damien DUPORTAL <damien.duportal@gmail.com>

This Pull Request introduce an alternative docker build based on Linux Alpine.

- A special GlibC build was needed
- LibWebSockets had to be built from source

The resulting image is ~68 Mb (~ 28 Mb when compressed from a docker registry).

You can find a pre-built version here: https://hub.docker.com/r/dduportal/ttyd/ to test