### PR TITLE
Bump debian pkg version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ttyd (1.3.3-1) unstable; urgency=medium
+
+  * New upstream release.
+
+ -- Boyuan Yang <073plan@gmail.com>  Mon, 24 Jul 2017 15:47:53 +0800
+
 ttyd (1.3.2-1) unstable; urgency=medium
 
   * New upstream release.


### PR DESCRIPTION
Please try to bump the version in `debian/changelog` as well next time when the new upstream version bumps. Thanks