### PR TITLE
Cleanup code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 cmake_policy(SET CMP0048 NEW)
 
-project(ttyd VERSION "1.3.3")
+project(ttyd VERSION "2.0.0.20200101")
 
 if(CMAKE_VERSION VERSION_LESS "3.1")
     if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")

--- a/src/http.c
+++ b/src/http.c
@@ -77,7 +77,10 @@ callback_http(struct lws *wsi, enum lws_callback_reasons reason, void *user, voi
             end = p + sizeof(buffer) - LWS_PRE;
 
             if (!strncmp((const char *) in, "/auth_token.js", 14)) {
-                size_t n = server->credential != NULL ? sprintf(buf, "var tty_auth_token = '%s';", server->credential) : 0;
+                size_t n = 0;
+                if (server->credential != NULL) {
+                  n = snprintf(buf, 256, "var tty_auth_token = '%s';", server->credential);
+                }
 
                 if (lws_add_http_header_status(wsi, HTTP_STATUS_OK, &p, end))
                     return 1;

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -99,7 +99,7 @@ tty_client_destroy(struct tty_client *client) {
     client->running = false;
 
     // kill process and free resource
-    lwsl_notice("tty_client_destroy sending:  %s (%d) to process %d\n", server->sig_name, server->sig_code, client->pid);
+    lwsl_notice("tty_client_destroy: sending  %s (%d) to process %d\n", server->sig_name, server->sig_code, client->pid);
     if (kill(client->pid, server->sig_code) != 0) {
         lwsl_err("kill: %d, errno: %d (%s)\n", client->pid, errno, strerror(errno));
     }

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -138,8 +138,16 @@ thread_run_command(void *args) {
                 perror("setenv");
                 exit(1);
             }
-            if (execvp(server->argv[0], server->argv) < 0) {
-                perror("execvp");
+            int e = -1;
+            if ( 0 == access(server->argv[0], R_OK | X_OK) ) {
+                e = execvp(server->argv[0], server->argv);
+            } else {
+                char *argp[] = {"sh", "-c", NULL, NULL};
+                argp[2] = server->argv[0];
+                e = execv("/bin/sh", argp);
+            } 
+            if (e < 0) {
+                perror("execv?");
                 exit(1);
             }
             break;

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -10,19 +10,20 @@ send_initial_message(struct lws *wsi) {
 
     char hostname[128];
     gethostname(hostname, sizeof(hostname) - 1);
+    hostname[127] = '\0';
 
     // window title
-    n = sprintf((char *) p, "%c%s (%s)", SET_WINDOW_TITLE, server->command, hostname);
+    n = snprintf((char *) p, 256 - LWS_PRE, "%c%s (%s)", SET_WINDOW_TITLE, server->argv[0], hostname);
     if (lws_write(wsi, p, (size_t) n, LWS_WRITE_TEXT) < n) {
         return -1;
     }
     // reconnect time
-    n = sprintf((char *) p, "%c%d", SET_RECONNECT, server->reconnect);
+    n = snprintf((char *) p, 12, "%c%d", SET_RECONNECT, server->reconnect);
     if (lws_write(wsi, p, (size_t) n, LWS_WRITE_TEXT) < n) {
         return -1;
     }
     // client preferences
-    n = sprintf((char *) p, "%c%s", SET_PREFERENCES, server->prefs_json);
+    n = snprintf((char *) p, 4, "%c{}", SET_PREFERENCES);
     if (lws_write(wsi, p, (size_t) n, LWS_WRITE_TEXT) < n) {
         return -1;
     }
@@ -65,7 +66,7 @@ check_host_origin(struct lws *wsi) {
         int port;
         if (lws_parse_uri(buf, &prot, &address, &port, &path))
             return false;
-        sprintf(buf, "%s:%d", address, port);
+        snprintf(buf, origin_length, "%s:%d", address, port);
         int host_length = lws_hdr_total_length(wsi, WSI_TOKEN_HOST);
         if (host_length != strlen(buf))
             return false;
@@ -98,7 +99,7 @@ tty_client_destroy(struct tty_client *client) {
     client->running = false;
 
     // kill process and free resource
-    lwsl_notice("sending %s (%d) to process %d\n", server->sig_name, server->sig_code, client->pid);
+    lwsl_notice("tty_client_destroy sending %s (%d) to process %d\n", server->sig_name, server->sig_code, client->pid);
     if (kill(client->pid, server->sig_code) != 0) {
         lwsl_err("kill: %d, errno: %d (%s)\n", client->pid, errno, strerror(errno));
     }
@@ -125,6 +126,7 @@ thread_run_command(void *args) {
     fd_set des_set;
 
     client = (struct tty_client *) args;
+    lwsl_notice("pre starting process, %d: %s %s\n", server->argc, server->argv[0], server->argv[1]);
     pid_t pid = forkpty(&pty, NULL, NULL, NULL);
 
     switch (pid) {
@@ -226,6 +228,7 @@ callback_tty(struct lws *wsi, enum lws_callback_reasons reason,
         case LWS_CALLBACK_SERVER_WRITEABLE:
             if (!client->initialized) {
                 if (send_initial_message(wsi) < 0) {
+                    lwsl_err("tty_client_remove: failed\n");
                     tty_client_remove(client);
                     lws_close_reason(wsi, LWS_CLOSE_STATUS_UNEXPECTED_CONDITION, NULL, 0);
                     return -1;
@@ -252,7 +255,7 @@ callback_tty(struct lws *wsi, enum lws_callback_reasons reason,
                 size_t msg_len = LWS_PRE + strlen(b64_text) + 1;
                 unsigned char message[msg_len];
                 unsigned char *p = &message[LWS_PRE];
-                size_t n = sprintf((char *) p, "%c%s", OUTPUT, b64_text);
+                size_t n = snprintf((char *) p, msg_len-LWS_PRE+1, "%c%s", OUTPUT, b64_text);
 
                 free(b64_text);
 

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -23,7 +23,7 @@ send_initial_message(struct lws *wsi) {
         return -1;
     }
     // client preferences
-    n = snprintf((char *) p, 4, "%c{}", SET_PREFERENCES);
+    n = snprintf((char *) p, 256, "%c%s", SET_PREFERENCES, server->client_opt);
     if (lws_write(wsi, p, (size_t) n, LWS_WRITE_TEXT) < n) {
         return -1;
     }

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -99,7 +99,7 @@ tty_client_destroy(struct tty_client *client) {
     client->running = false;
 
     // kill process and free resource
-    lwsl_notice("tty_client_destroy sending %s (%d) to process %d\n", server->sig_name, server->sig_code, client->pid);
+    lwsl_notice("tty_client_destroy sending:  %s (%d) to process %d\n", server->sig_name, server->sig_code, client->pid);
     if (kill(client->pid, server->sig_code) != 0) {
         lwsl_err("kill: %d, errno: %d (%s)\n", client->pid, errno, strerror(errno));
     }
@@ -126,7 +126,6 @@ thread_run_command(void *args) {
     fd_set des_set;
 
     client = (struct tty_client *) args;
-    lwsl_notice("pre starting process, %d: %s %s\n", server->argc, server->argv[0], server->argv[1]);
     pid_t pid = forkpty(&pty, NULL, NULL, NULL);
 
     switch (pid) {

--- a/src/server.c
+++ b/src/server.c
@@ -33,6 +33,7 @@ static const struct option options[] = {
         {"ssl-key",      required_argument, NULL, 'K'},
         {"ssl-ca",       required_argument, NULL, 'A'},
         {"readonly",     no_argument,       NULL, 'R'},
+        {"client-option",required_argument, NULL, 't'},
         {"check-origin", no_argument,       NULL, 'O'},
         {"max-clients",  required_argument, NULL, 'm'},
         {"once",         no_argument,       NULL, 'o'},
@@ -42,7 +43,7 @@ static const struct option options[] = {
         {"help",         no_argument,       NULL, 'h'},
         {NULL,           0,                 0,     0}
 };
-static const char *opt_string = "+A:Bc:C:g:hi:I:K:l:m:Oop:r:Rs:Su:v";
+static const char *opt_string = "+A:Bc:C:g:hi:I:K:l:m:Oop:r:Rs:St:u:v";
 
 void print_help() {
     fprintf(stderr, "ttyd is a tool for sharing terminal over the web\n\n"
@@ -149,7 +150,6 @@ main(int argc, char **argv) {
     char key_path[1024] = "";
     char ca_path[1024] = "";
 
-    // parse command line options
     int c;
     char* end; // parsing int
     while ((c = getopt_long(argc, argv, opt_string, options, NULL)) != -1) {
@@ -171,6 +171,20 @@ main(int argc, char **argv) {
                 break;
             case 'R':
                 server->readonly = true;
+                break;
+            case 't':{
+                    struct json_object *obj = json_tokener_parse(optarg);
+                    if (obj == NULL) {
+                        fprintf(stderr, "ttyd: client-option: takes json as arg not %s\n", optarg);
+                        return -1;
+                    }
+                    if (strlen(optarg) > 254) {
+                        fprintf(stderr, "ttyd: client-option: takes json as arg less than 254 char sorry , not %s\n", optarg);
+                        return -1;
+                    }
+                    json_object_put (obj);
+                    server->client_opt = optarg;
+                }
                 break;
             case 'O':
                 server->check_origin = true;

--- a/src/server.c
+++ b/src/server.c
@@ -163,9 +163,6 @@ main(int argc, char **argv) {
             case 'v':
                 printf("ttyd version %s\n", TTYD_VERSION);
                 return 0;
-            case 'd':
-                daemonize = 1;
-                break;
             case 'l': {
                     long x = strtol(optarg, &end,  10);
                     if (end - optarg != strlen(optarg)) {

--- a/src/server.c
+++ b/src/server.c
@@ -201,7 +201,7 @@ main(int argc, char **argv) {
             case 'p': {
                     long x = strtol(optarg, &end,  10);
                     if (end - optarg != strlen(optarg) || x < 0 || x > 65535) {
-                        fprintf(stderr, "ttyd: -p: takes port number  argument not %s\n", optarg);
+                        fprintf(stderr, "ttyd: -p: takes port number argument not %s\n", optarg);
                         return -1;
                     }
                     info.port = x;

--- a/src/server.c
+++ b/src/server.c
@@ -272,9 +272,7 @@ main(int argc, char **argv) {
                 ca_path[sizeof(ca_path) - 1] = '\0';
                 break;
             case ':':
-                    fprintf(stderr, "ttyd: got :\n", optind);
             case '?':
-                    fprintf(stderr, "ttyd: got ?\n", optind);
             default:
                 print_help();
                 return -1;

--- a/src/server.c
+++ b/src/server.c
@@ -60,7 +60,7 @@ void print_help() {
                     "    --signal, -s            Signal to send to the command when exit it (default: SIGHUP)\n"
                     "    --reconnect, -r         Time to reconnect for the client in seconds (default: 10)\n"
                     "    --readonly, -R          Do not allow clients to write to the TTY\n"
-                    "    --client-option, -t     Send option to client (format: key=value), repeat to add more options\n"
+                    "    --client-option, -t     Send option to client (format: { \"key\":\"value\", ... } )\n"
                     "    --check-origin, -O      Do not allow websocket connection from different origin\n"
                     "    --max-clients, -m       Maximum clients to support (default: 0, no limit)\n"
                     "    --once, -o              Accept only one client and exit on disconnection\n"
@@ -246,7 +246,7 @@ main(int argc, char **argv) {
                 if (!strncmp(optarg, "~/", 2)) {
                     const char* home = getenv("HOME");
                     int index_size = strlen(home) + strlen(optarg) - 1;
-                    server->index = malloc(index_size);
+                    server->index = xmalloc(index_size);
                     snprintf(server->index, index_size,"%s%s", home, optarg + 1);
                 } else {
                     server->index = strdup(optarg);

--- a/src/server.c
+++ b/src/server.c
@@ -43,7 +43,7 @@ static const struct option options[] = {
         {"help",         no_argument,       NULL, 'h'},
         {NULL,           0,                 0,     0}
 };
-static const char *opt_string = "l:p:i:c:u:g:s:r:I:aSC:K:A:Rt:Om:oBd:vhd";
+static const char *opt_string = "+A:Bc:C:dg:hi:I:K:l:m:Oop:r:Rs:Su:v";
 
 void print_help() {
     fprintf(stderr, "ttyd is a tool for sharing terminal over the web\n\n"
@@ -272,18 +272,18 @@ main(int argc, char **argv) {
                 ca_path[sizeof(ca_path) - 1] = '\0';
                 break;
             case ':':
+                    fprintf(stderr, "ttyd: got :\n", optind);
             case '?':
+                    fprintf(stderr, "ttyd: got ?\n", optind);
             default:
                 print_help();
                 return -1;
         }
-        // test if command start
-        if ( 0 == access(argv[optind], R_OK | X_OK) ) {
-            server->argc = argc - optind;
-            server->argv = &argv[optind];
-            break;
-        }
     }
+    argc -= optind;
+    argv += optind;
+    server->argc = argc;
+    server->argv = argv;
 
     if ( server->argc < 1 ) {
         tty_server_free(server);
@@ -343,7 +343,7 @@ main(int argc, char **argv) {
         lwsl_notice("  credential: %s\n", server->credential);
     
     lwsl_notice("  start command: \n");
-    for (c = optind; c < argc; c++) {
+    for (c = 0; c < argc; c++) {
         lwsl_notice(" %s\n", argv[c]);
     }
     lwsl_notice("\n");

--- a/src/server.c
+++ b/src/server.c
@@ -38,12 +38,11 @@ static const struct option options[] = {
         {"once",         no_argument,       NULL, 'o'},
         {"browser",      no_argument,       NULL, 'B'},
         {"log",          required_argument, NULL, 'l'},
-        {"daemon",       no_argument,       NULL, 'd'},
         {"version",      no_argument,       NULL, 'v'},
         {"help",         no_argument,       NULL, 'h'},
         {NULL,           0,                 0,     0}
 };
-static const char *opt_string = "+A:Bc:C:dg:hi:I:K:l:m:Oop:r:Rs:Su:v";
+static const char *opt_string = "+A:Bc:C:g:hi:I:K:l:m:Oop:r:Rs:Su:v";
 
 void print_help() {
     fprintf(stderr, "ttyd is a tool for sharing terminal over the web\n\n"
@@ -71,7 +70,6 @@ void print_help() {
                     "    --ssl-key, -K           SSL key file path\n"
                     "    --ssl-ca, -A            SSL CA file path for client certificate verification\n"
                     "    --log, -l               Set log level (default: 7)\n"
-                    "    --daemonize, -d         Fork to background\n"
                     "    --version, -v           Print the version and exit\n"
                     "    --help, -h              Print this text and exit\n\n"
                     "Visit https://github.com/tsl0922/ttyd to get more information and report bugs.\n",
@@ -129,7 +127,6 @@ sig_handler(int sig) {
 
 int
 main(int argc, char **argv) {
-    int daemonize = 0;
 
     server = tty_server_new();
 
@@ -362,8 +359,7 @@ main(int argc, char **argv) {
     }
 
     signal(SIGINT, sig_handler);  // ^C
-    if (!daemonize)
-      signal(SIGTERM, sig_handler); // kill
+    signal(SIGTERM, sig_handler); // kill
 
     context = lws_create_context(&info);
     if (context == NULL) {
@@ -376,9 +372,6 @@ main(int argc, char **argv) {
         snprintf(url, 30, "%s://localhost:%d", ssl ? "https" : "http", info.port);
         open_uri(url);
     }
-
-    if (daemonize)
-      daemon(0, 0);
 
     // libwebsockets main loop
     while (!force_exit) {

--- a/src/server.c
+++ b/src/server.c
@@ -116,10 +116,7 @@ void
 sig_handler(int sig) {
     if (force_exit)
         exit(EXIT_FAILURE);
-
-    char sig_name[20];
-    get_sig_name(sig, sig_name, 20);
-    lwsl_notice("received signal: %s (%d), exiting...\n", sig_name, sig);
+    lwsl_notice("received signal: %s (%d), exiting...\n", strsignal(sig), sig);
     force_exit = true;
     lws_cancel_service(context);
     lwsl_notice("send ^C to force exit.\n");

--- a/src/server.h
+++ b/src/server.h
@@ -100,11 +100,10 @@ struct tty_client {
 struct tty_server {
     LIST_HEAD(client, tty_client) clients;    // client list
     int client_count;                         // client count
-    char *prefs_json;                         // client preferences
     char *credential;                         // encoded basic auth credential
     int reconnect;                            // reconnect timeout
     char *index;                              // custom index.html
-    char *command;                            // full command line
+    int argc;                                 // command with arguments
     char **argv;                              // command with arguments
     int sig_code;                             // close signal
     char *sig_name;                           // human readable signal string

--- a/src/server.h
+++ b/src/server.h
@@ -108,6 +108,7 @@ struct tty_server {
     int sig_code;                             // close signal
     char *sig_name;                           // human readable signal string
     bool readonly;                            // whether not allow clients to write to the TTY
+    char* client_opt;                         // json string to pass to xterm.js
     bool check_origin;                        // whether allow websocket connection from different origin
     int max_clients;                          // maximum clients to support
     bool once;                                // whether accept only one client and exit on disconnection

--- a/src/utils.c
+++ b/src/utils.c
@@ -69,8 +69,8 @@ endswith(const char *str, const char *suffix) {
 }
 
 int
-get_sig_name(int sig, char *buf) {
-    int n = sprintf(buf, "SIG%s", sig < NSIG ? sys_signame[sig] : "unknown");
+get_sig_name(int sig, char *buf, size_t s) {
+    int n = snprintf(buf, s, "SIG%s", sig < NSIG ? sys_signame[sig] : "unknown");
     uppercase(buf);
     return n;
 }
@@ -88,21 +88,11 @@ get_sig(const char *sig_name) {
     return -1;
 }
 
-void print_sig_list() {
-    char name[30];
-    for (int sig = 1; sig < NSIG; sig++) {
-        if (sys_signame[sig] != NULL) {
-            strcpy(name, sys_signame[sig]);
-            printf("%2d) SIG%s (%s)\n", sig, uppercase(name), strsignal(sig));
-        }
-    }
-}
-
 int
 open_uri(char *uri) {
 #ifdef __APPLE__
     char command[256];
-    sprintf(command, "open %s > /dev/null 2>&1", uri);
+    snprintf(command, 256, "open %s > /dev/null 2>&1", uri);
     return system(command);
 #elif defined(_WIN32) || defined(__CYGWIN__)
     return ShellExecute(0, 0, uri, 0, 0 , SW_SHOW) > 32 ? 0 : 1;
@@ -111,7 +101,7 @@ open_uri(char *uri) {
     if (system("xset -q > /dev/null 2>&1"))
         return 1;
     char command[256];
-    sprintf(command, "xdg-open %s > /dev/null 2>&1", uri);
+    snprintf(command, 256, "xdg-open %s > /dev/null 2>&1", uri);
     return system(command);
 #endif
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -69,13 +69,6 @@ endswith(const char *str, const char *suffix) {
 }
 
 int
-get_sig_name(int sig, char *buf, size_t s) {
-    int n = snprintf(buf, s, "SIG%s", sig < NSIG ? sys_signame[sig] : "unknown");
-    uppercase(buf);
-    return n;
-}
-
-int
 get_sig(const char *sig_name) {
     if (strlen(sig_name) <= 3 || strcasestr(sig_name, "sig") == NULL) {
         return -1;

--- a/src/utils.h
+++ b/src/utils.h
@@ -17,10 +17,6 @@ uppercase(char *str);
 bool
 endswith(const char *str, const char *suffix);
 
-// Get human readable signal string
-int
-get_sig_name(int sig, char *buf, size_t s);
-
 // Get signal code from string like SIGHUP
 int
 get_sig(const char *sig_name);

--- a/src/utils.h
+++ b/src/utils.h
@@ -19,15 +19,11 @@ endswith(const char *str, const char *suffix);
 
 // Get human readable signal string
 int
-get_sig_name(int sig, char *buf);
+get_sig_name(int sig, char *buf, size_t s);
 
 // Get signal code from string like SIGHUP
 int
 get_sig(const char *sig_name);
-
-// print signal list
-void
-print_sig_list();
 
 // Open uri with the default application of system
 int


### PR DESCRIPTION
Modifying the command line to change -d for more classic demonize
and using -l for log level as often found in program,

i ended up detected a lot of dead code or almost useless code.

Moreover I replace all string copy that weren't checking for size 
to reduce the number of warnings

Tested on openBSD and Ubuntu

--


