### PR TITLE
Add instructions for Gentoo Linux users

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ brew install ttyd
     ```
 
     You may also need to compile/install [libwebsockets][2] from source if the `libwebsockets-dev` package is outdated.
+    
+- Install on Gentoo:
+clone the repo at [https://bitbucket.org/mgpagano/ttyd/src/master/](https://bitbucket.org/mgpagano/ttyd/src/master/) and follow the directions [here](https://wiki.gentoo.org/wiki/Custom_repository#Creating_a_local_repository) for creating a local repository.
+
 
 ## Install on Windows
 


### PR DESCRIPTION
I wrote a live-ebuild for Gentoo users to facilitate installation of ttyd.  It's a work in progress and I hope to add the ability to install releases and not only from HEAD.  I am an official Gentoo Developer, but I want to work this separate from our infrastructure to ensure the quality before committing to the main tree.