### PR TITLE
Close websocket after forking to keep child processes from blocking new connections

### DIFF
--- a/src/protocol.c
+++ b/src/protocol.c
@@ -180,6 +180,8 @@ thread_run_command(void *args) {
                 perror("setenv");
                 pthread_exit((void *) 1);
             }
+            // Don't pass the web socket onto child processes
+            close(lws_get_socket_fd(client->wsi));
             if (execvp(server->argv[0], server->argv) < 0) {
                 perror("execvp");
                 pthread_exit((void *) 1);


### PR DESCRIPTION
After forking, the websocket file descriptor is cloned and stored with the process.  After exec'ing the new function, there is no way to close the cloned file descriptor, which means that it won't be cleaned up until the whole process tree is cleaned up.

As long as it stays open, the original socket is blocked, which prevents us from restarting ttyd and reattaching to the original socket.

This change closes the socket so that it isn't leaked into child processes, meaning we can safely detach child processes and reconnect across sessions.