### PR TITLE
Update max_heaser_data from default(4K) to 20K

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -240,6 +240,7 @@ main(int argc, char **argv) {
     info.max_http_header_pool = 16;
     info.options = LWS_SERVER_OPTION_VALIDATE_UTF8 | LWS_SERVER_OPTION_DISABLE_IPV6;
     info.extensions = extensions;
+    info.max_http_header_data = 20480;
 
     int debug_level = LLL_ERR | LLL_WARN | LLL_NOTICE;
     char iface[128] = "";


### PR DESCRIPTION
I've experienced `Ran out of header data space` while I have multiple sessions stored in my development server. (The different http servers runs on 3000,5000 and 8080 and stored cookie as a single domain) .
From [an issue](https://github.com/warmcat/libwebsockets/issues/1270),  libwebsocket has options to increase this.  For now,  just increase 5 times bigger than default(4096), which is sufficient for the most of the case, I believe.

Cookie section of request header is fat and it seems no way to control header from websocket JS api.
![image](https://user-images.githubusercontent.com/1880965/54573410-8bbf5000-4a2f-11e9-945e-5d9938f341a1.png)
