### PR TITLE
运行 login 命令的必要条件

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Then open <http://localhost:8080> with a browser, you will get a bash shell with
 
 **More Examples:**
 
-- If you want to login with your system accounts on the web browser, run `ttyd login`.
+- If you want to login with your system accounts on the web browser, run `ttyd login`. You may need to set `/etc/securetty` first, for example: `printf "pts/0\npts/1\npts/2\npts/3\n" >> /etc/securetty`.
 - You can even run a none shell command like vim, try: `ttyd vim`, the web browser will show you a vim editor.
 - Sharing single process with multiple clients: `ttyd tmux new -A -s ttyd vim`, run `tmux new -A -s ttyd` to connect to the tmux session from terminal.
 


### PR DESCRIPTION
CentOS 7.x 下运行 login  命令需要先设置 `/etc/securetty` 这个文件。例如:
```
cat <<'EOF' >> /etc/securetty
pts/1
pts/2
pts/3
pts/4
pts/5
pts/6
pts/7
pts/8
pts/9
pts/10
pts/11
EOF
```