### PR TITLE
include pthread.h for pthread_mutex_t

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1,3 +1,4 @@
+#include <pthread.h>
 #include <stdbool.h>
 #include <sys/ioctl.h>
 #include <sys/queue.h>


### PR DESCRIPTION
Needed to unbreak build on OpenBSD.