### PR TITLE
use errno.h not sys/errno.h in utils.c as in other files

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -4,7 +4,7 @@
 #include <ctype.h>
 #include <string.h>
 #include <signal.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/wait.h>
 
 #ifdef __linux__


### PR DESCRIPTION
Use errno.h rather than sysno/errno.h in utils.c, unbreaking build on OpenBSD (the "errno" symbol is only defined in errno.h not in sys/errno.h).

protocol.c and server.c already include errno.h rather than sys/errno.h so this should be safe on other OS here also.