### PR TITLE
Avoid slow reverse-DNS requests caused by libwebsocket

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ if(WIN32)
     list(APPEND LINK_LIBS shell32)
 endif()
 
-option(SIMPLE_ACCESS_LOG "Only print clent ip in access log" OFF)
+option(SIMPLE_ACCESS_LOG "Only print client ip in access log" OFF)
 if (SIMPLE_ACCESS_LOG)
     add_definitions(-DSIMPLE_ACCESS_LOG)
     message(STATUS "Use SIMPLE_ACCESS_LOG")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,12 @@ if(WIN32)
     list(APPEND LINK_LIBS shell32)
 endif()
 
+option(SIMPLE_ACCESS_LOG "Only print clent ip in access log" OFF)
+if (SIMPLE_ACCESS_LOG)
+    add_definitions(-DSIMPLE_ACCESS_LOG)
+    message(STATUS "Use SIMPLE_ACCESS_LOG")
+endif()
+
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 target_include_directories(${PROJECT_NAME} PUBLIC ${INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,12 +82,6 @@ if(WIN32)
     list(APPEND LINK_LIBS shell32)
 endif()
 
-option(SIMPLE_ACCESS_LOG "Only print client ip in access log" OFF)
-if (SIMPLE_ACCESS_LOG)
-    add_definitions(-DSIMPLE_ACCESS_LOG)
-    message(STATUS "Use SIMPLE_ACCESS_LOG")
-endif()
-
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 target_include_directories(${PROJECT_NAME} PUBLIC ${INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS})

--- a/src/http.c
+++ b/src/http.c
@@ -62,14 +62,24 @@ check_auth(struct lws *wsi, struct pss_http *pss) {
 }
 
 void access_log(struct lws *wsi, const char *path) {
-    char name[100], rip[50];
+    char rip[50];
+#ifndef SIMPLE_ACCESS_LOG
+    char name[100];
+#endif
+
 #if LWS_LIBRARY_VERSION_MAJOR >=2 && LWS_LIBRARY_VERSION_MINOR >=4
     struct lws *n_wsi = lws_get_network_wsi(wsi);
 #else
     struct lws *n_wsi = wsi;
 #endif
+
+#ifdef SIMPLE_ACCESS_LOG
+    lws_get_peer_simple(wsi, rip, sizeof(rip));
+    lwsl_notice("HTTP %s - %s\n", path, rip);
+#else
     lws_get_peer_addresses(wsi, lws_get_socket_fd(n_wsi), name, sizeof(name), rip, sizeof(rip));
     lwsl_notice("HTTP %s - %s (%s)\n", path, rip, name);
+#endif
 }
 
 int

--- a/src/http.c
+++ b/src/http.c
@@ -63,9 +63,6 @@ check_auth(struct lws *wsi, struct pss_http *pss) {
 
 void access_log(struct lws *wsi, const char *path) {
     char rip[50];
-#ifndef SIMPLE_ACCESS_LOG
-    char name[100];
-#endif
 
 #if LWS_LIBRARY_VERSION_MAJOR >=2 && LWS_LIBRARY_VERSION_MINOR >=4
     struct lws *n_wsi = lws_get_network_wsi(wsi);
@@ -73,13 +70,8 @@ void access_log(struct lws *wsi, const char *path) {
     struct lws *n_wsi = wsi;
 #endif
 
-#ifdef SIMPLE_ACCESS_LOG
     lws_get_peer_simple(wsi, rip, sizeof(rip));
     lwsl_notice("HTTP %s - %s\n", path, rip);
-#else
-    lws_get_peer_addresses(wsi, lws_get_socket_fd(n_wsi), name, sizeof(name), rip, sizeof(rip));
-    lwsl_notice("HTTP %s - %s (%s)\n", path, rip, name);
-#endif
 }
 
 int


### PR DESCRIPTION
According to warmcat/libwebsockets#537 and following my own experience, in some circumstances lws_get_peer_addresses can take several seconds to execute a reverse DNS request on a connected peer IP. The effect is that sometimes a websocket connection takes several seconds before it is established.
This PR addresses the described issue by replacing lws_get_peer_addresses with lws_get_peer_simple that completely skips the RDNS request.

Signed-off-by: Xiang Dai <764524258@qq.com>