### PR TITLE
Fix for upgrade of libwebsockets 3.2.0

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -50,6 +50,10 @@ struct tty_client {
     pthread_cond_t cond;
 
     LIST_ENTRY(tty_client) list;
+
+#if LWS_LIBRARY_VERSION_NUMBER >= 3002000
+    lws_sorted_usec_list_t sul_stagger;
+#endif
 };
 
 struct pss_http {


### PR DESCRIPTION
In libwebsockets 3.2.0 it removes the internal poll which breaks every second, so application code should add a schedule event for tty client.

Reference:
[1] https://github.com/warmcat/libwebsockets/issues/1685
[2] https://libwebsockets.org/git/libwebsockets/tree/READMEs/README.lws_sul.md