### PR TITLE
Avoid trying to redefine sys_signame on Android

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -6,7 +6,7 @@
 #include <signal.h>
 #include <fcntl.h>
 
-#ifdef __linux__
+#if defined(__linux__) && !defined(__ANDROID__)
 // https://github.com/karelzak/util-linux/blob/master/misc-utils/kill.c
 const char *sys_signame[NSIG] = {
     "zero",  "HUP",  "INT",   "QUIT", "ILL",   "TRAP", "ABRT", "UNUSED",


### PR DESCRIPTION
On Android <signal.h> defines sys_signame, so trying to redefine it causes the build to fail.

This patch is used when building ttyd for [Termux](https://termux.com/).