### PR TITLE
server: handle port 0

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -483,9 +483,22 @@ main(int argc, char **argv) {
         return 1;
     }
 
+#if LWS_LIBRARY_VERSION_MAJOR >= 3
+    struct lws_vhost *vhost = lws_get_vhost_by_name(context, "default");
+    if (vhost == NULL) {
+        lwsl_err("libwebsockets default vhost creation failed\n");
+        return 1;
+    }
+
+    int port = lws_get_vhost_listen_port(vhost);
+    lwsl_notice("  listening on port: %d\n", port);
+#else
+    int port = info.port;
+#endif
+
     if (browser) {
         char url[30];
-        sprintf(url, "%s://localhost:%d", ssl ? "https" : "http", info.port);
+        sprintf(url, "%s://localhost:%d", ssl ? "https" : "http", port);
         open_uri(url);
     }
 


### PR DESCRIPTION
Currently, if a user selects port 0 (as advertised in the help menu), there is
no way for the user to trivially find ttyd's port. This commit resolves the
issue by logging the port to the console and by opening a URL with the correct
port information if a user has selected such an option.