### PR TITLE
http: add missing header

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <libwebsockets.h>
+#include <openssl/ssl.h>
 
 #include "server.h"
 #include "html.h"


### PR DESCRIPTION
Fixes compilation without deprecated OpenSSL APIs.