### PR TITLE
Add -b, --base-path option for reverse proxies (#151)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ OPTIONS:
     -o, --once              Accept only one client and exit on disconnection
     -B, --browser           Open terminal with the default system browser
     -I, --index             Custom index.html path
+    -b, --base-path         Expected base path for requests coming from a reverse proxy (eg: /mounted/here)
     -6, --ipv6              Enable IPv6 support
     -S, --ssl               Enable SSL
     -C, --ssl-cert          SSL certificate file path

--- a/src/http.c
+++ b/src/http.c
@@ -149,7 +149,7 @@ callback_http(struct lws *wsi, enum lws_callback_reasons reason, void *user, voi
             p = buffer + LWS_PRE;
             end = p + sizeof(buffer) - LWS_PRE;
 
-            if (strncmp(pss->path, "/token", 6) == 0) {
+            if (strcmp(pss->path, endpoints.token) == 0) {
                 const char *credential = server->credential != NULL ? server->credential : "";
                 size_t n = sprintf(buf, "{\"token\": \"%s\"}", credential);
                 if (lws_add_http_header_status(wsi, HTTP_STATUS_OK, &p, end))
@@ -171,7 +171,7 @@ callback_http(struct lws *wsi, enum lws_callback_reasons reason, void *user, voi
                 break;
             }
 
-            if (strcmp(pss->path, "/") != 0) {
+            if (strcmp(pss->path, endpoints.index) != 0) {
                 lws_return_http_status(wsi, HTTP_STATUS_NOT_FOUND, NULL);
                 goto try_to_reuse;
             }

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -251,7 +251,7 @@ callback_tty(struct lws *wsi, enum lws_callback_reasons reason,
                 lwsl_warn("refuse to serve WS client due to the --max-clients option.\n");
                 return 1;
             }
-            if (lws_hdr_copy(wsi, buf, sizeof(buf), WSI_TOKEN_GET_URI) <= 0 || strcmp(buf, WS_PATH) != 0) {
+            if (lws_hdr_copy(wsi, buf, sizeof(buf), WSI_TOKEN_GET_URI) <= 0 || strcmp(buf, endpoints.ws) != 0) {
                 lwsl_warn("refuse to serve WS client for illegal ws path: %s\n", buf);
                 return 1;
             }

--- a/src/server.c
+++ b/src/server.c
@@ -365,7 +365,7 @@ main(int argc, char **argv) {
             case 'b': {
                 char path[128];
                 strncpy(path, optarg, 128);
-                int len = strlen(path);
+                size_t len = strlen(path);
                 #define sc(f) \
                   strncpy(path + len, endpoints.f, 128 - len); \
                   endpoints.f = strdup(path);

--- a/src/server.h
+++ b/src/server.h
@@ -13,12 +13,17 @@
 #define SET_WINDOW_TITLE '1'
 #define SET_PREFERENCES '2'
 
-// websocket url path
-#define WS_PATH "/ws"
+// url paths
+struct endpoints {
+    char *ws;
+    char *index;
+    char *token;
+};
 
 extern volatile bool force_exit;
 extern struct lws_context *context;
 extern struct server *server;
+extern struct endpoints endpoints;
 
 typedef enum {
     STATE_INIT, STATE_KILL, STATE_EXIT


### PR DESCRIPTION
The implementation is pretty straightforward, I replaced the hardcoded paths with an endpoint table, which by default has the hardcoded values, but can be prefixed with the value of the --base-path option.

Also, the following line (src/http.c:152) `if (strncmp(pss->path, "/token", 6) == 0) {` would match the url `/tokenwhatevercomesnext`, which I guess was not the intended goal. I changed to a regular strcmp which limits to the smallest string.