### PR TITLE
Improvements for --base-path usage

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -160,6 +160,20 @@ int callback_http(struct lws *wsi, enum lws_callback_reasons reason, void *user,
         break;
       }
 
+      // accessing `/base-path` redirects to `/base-path/`
+      if (strcmp(pss->path, endpoints.parent) == 0) {
+        if (lws_add_http_header_status(wsi, HTTP_STATUS_FOUND, &p, end)
+            || lws_add_http_header_by_name(wsi, "location:", endpoints.index,
+                                           strlen(endpoints.index), &p, end)
+            || lws_add_http_header_content_length(wsi, 0, &p, end)
+            || lws_finalize_http_header(wsi, &p, end)
+            || lws_write(wsi, buffer + LWS_PRE, p - (buffer + LWS_PRE),
+                         LWS_WRITE_HTTP_HEADERS) < 0
+        )
+          return 1;
+        goto try_to_reuse;
+      }
+
       if (strcmp(pss->path, endpoints.index) != 0) {
         lws_return_http_status(wsi, HTTP_STATUS_NOT_FOUND, NULL);
         goto try_to_reuse;

--- a/src/http.c
+++ b/src/http.c
@@ -163,8 +163,9 @@ int callback_http(struct lws *wsi, enum lws_callback_reasons reason, void *user,
       // accessing `/base-path` redirects to `/base-path/`
       if (strcmp(pss->path, endpoints.parent) == 0) {
         if (lws_add_http_header_status(wsi, HTTP_STATUS_FOUND, &p, end)
-            || lws_add_http_header_by_name(wsi, "location:", endpoints.index,
-                                           strlen(endpoints.index), &p, end)
+            || lws_add_http_header_by_token(wsi, WSI_TOKEN_HTTP_LOCATION,
+                                            endpoints.index,
+                                            strlen(endpoints.index), &p, end)
             || lws_add_http_header_content_length(wsi, 0, &p, end)
             || lws_finalize_http_header(wsi, &p, end)
             || lws_write(wsi, buffer + LWS_PRE, p - (buffer + LWS_PRE),

--- a/src/server.c
+++ b/src/server.c
@@ -20,7 +20,7 @@
 volatile bool force_exit = false;
 struct lws_context *context;
 struct server *server;
-struct endpoints endpoints = {"/ws", "/", "/token"};
+struct endpoints endpoints = {"/ws", "/", "/token", ""};
 
 extern int callback_http(struct lws *wsi, enum lws_callback_reasons reason,
                          void *user, void *in, size_t len);
@@ -375,7 +375,7 @@ int main(int argc, char **argv) {
 #define sc(f)                                  \
   strncpy(path + len, endpoints.f, 128 - len); \
   endpoints.f = strdup(path);
-        sc(ws) sc(index) sc(token)
+        sc(ws) sc(index) sc(token) sc(parent)
 #undef sc
       } break;
       case '6':

--- a/src/server.c
+++ b/src/server.c
@@ -370,6 +370,8 @@ int main(int argc, char **argv) {
         char path[128];
         strncpy(path, optarg, 128);
         size_t len = strlen(path);
+        while (len && path[len - 1] == '/') path[--len] = 0; // trim trailing /
+        if (!len) break;
 #define sc(f)                                  \
   strncpy(path + len, endpoints.f, 128 - len); \
   endpoints.f = strdup(path);

--- a/src/server.c
+++ b/src/server.c
@@ -486,6 +486,13 @@ int main(int argc, char **argv) {
   lwsl_notice("  start command: %s\n", server->command);
   lwsl_notice("  close signal: %s (%d)\n", server->sig_name, server->sig_code);
   lwsl_notice("  terminal type: %s\n", server->terminal_type);
+  if (endpoints.parent[0]) {
+    lwsl_notice("endpoints:\n");
+    lwsl_notice("  base-path: %s\n", endpoints.parent);
+    lwsl_notice("  index    : %s\n", endpoints.index);
+    lwsl_notice("  token    : %s\n", endpoints.token);
+    lwsl_notice("  websocket: %s\n", endpoints.ws);
+  }
   if (server->check_origin) lwsl_notice("  check origin: true\n");
   if (server->url_arg) lwsl_notice("  allow url arg: true\n");
   if (server->readonly) lwsl_notice("  readonly: true\n");

--- a/src/server.h
+++ b/src/server.h
@@ -18,6 +18,7 @@ struct endpoints {
   char *ws;
   char *index;
   char *token;
+  char *parent;
 };
 
 extern volatile bool force_exit;


### PR DESCRIPTION
Common errors such as the one reported in #289 are eliminated with this PR. Additionally, the full endpoints are displayed to the user if the --base-path option is specified, making it easier to debug in case the user is providing incorrect input.