### PR TITLE
Set URL of stylesheet by href

### DIFF
--- a/html/src/template.html
+++ b/html/src/template.html
@@ -6,7 +6,7 @@
     <title><%= htmlWebpackPlugin.options.title %></title>
     <link inline rel="icon" type="image/png" href="favicon.png">
     <% for (const css in htmlWebpackPlugin.files.css) { %>
-    <link inline rel="stylesheet" src="<%= htmlWebpackPlugin.files.css[css] %>">
+    <link rel="stylesheet" type="text/css" href="<%= htmlWebpackPlugin.files.css[css] %>">
     <% } %>
 </head>
 <body>


### PR DESCRIPTION
URL should be set with attribute `href`, `src` is no longer supportd by new browsers