### PR TITLE
fix readonly handling

### DIFF
--- a/src/protocol.c
+++ b/src/protocol.c
@@ -358,7 +358,7 @@ int callback_tty(struct lws *wsi, enum lws_callback_reasons reason, void *user, 
       switch (command) {
         case INPUT:
           if (proc->pty == 0) break;
-          if (server->readonly) return 0;
+          if (server->readonly) break;
 
           char *data = xmalloc(pss->len - 1);
           memcpy(data, pss->buffer + 1, pss->len - 1);


### PR DESCRIPTION
Previously, if running in readonly mode (`-R`), we would keep
accumulating incoming websocket data to `pss->buffer`, resizing it with
every incoming message. This would also break the `RESIZE` operation as
we would never get rid of the `INPUT` message.

Now we discard `INPUT` messages in `readonly` mode, 1) allowing resize
to work and 2) preventing the buffer from growing indefinitely.

Tested by running `./ttyd -R tmux attach -r` and verifying that resize now works when it didn't before.