### PR TITLE
cmake: fix build without C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
-project(ttyd)
+project(ttyd C)
 set(PROJECT_VERSION "1.6.0")
 
 find_package(Git)


### PR DESCRIPTION
Specify that ttyd is a C project to avoid the
following build failure if a C++ compiler isn't found.

CMake Error at CMakeLists.txt:3 (project):
  The CMAKE_CXX_COMPILER:

    /home/bartekk/Projects/buildroots/buildroot-dev/buildroot/output/host/bin/arm-buildroot-linux-uclibcgnueabihf-g++

  is not a full path to an existing compiler tool.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>