### PR TITLE
src/http.c: fix checking pss's len member

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -212,7 +212,7 @@ int callback_http(struct lws *wsi, enum lws_callback_reasons reason, void *user,
       break;
 
     case LWS_CALLBACK_HTTP_WRITEABLE:
-      if (!pss->buffer || pss->len <= 0) {
+      if (!pss->buffer || pss->len == 0) {
         goto try_to_reuse;
       }
 


### PR DESCRIPTION
len member is a size_t type so it can't be less than 0 by definition.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>