### PR TITLE
permission denied error - fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ brew install ttyd
     cmake ..
     make && make install
     ```
-    If make && make intsall gives you an error(permission denied). Try this
+    If make && make intsall gives you an error(permission denied). Try this out
     ```
     sudo make install
     ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ brew install ttyd
     cmake ..
     make && make install
     ```
-
+    If make && make intsall gives you an error(permission denied). Try this
+    ```
+    sudo make install
+    ```
     You may also need to compile/install [libwebsockets](https://libwebsockets.org) from source if the `libwebsockets-dev` package is outdated.
 
 - Install on Gentoo: clone the [repo](https://bitbucket.org/mgpagano/ttyd/src/master) and follow the directions [here](https://wiki.gentoo.org/wiki/Custom_repository#Creating_a_local_repository).


### PR DESCRIPTION
I got an error stating "permission denied to copy from /Software/ttyd to /usr/bin ". while installing ttyd.

I used sudo and that didn't help.

Then I found the solution [here](https://askubuntu.com/questions/954869/error-in-make-install-cannot-copy-file)

And then it started to install and now it's working.

Hope this helps some of you facing the same problem.