### PR TITLE
Added customHTML command

### DIFF
--- a/html/gulpfile.js
+++ b/html/gulpfile.js
@@ -53,3 +53,11 @@ task('default', () => {
         .pipe(rename("html.h"))
         .pipe(dest('../src/'));
 });
+
+task('customHTML', () => {
+    return src('dist/index.html')
+        .pipe(inlineSource())
+	.pipe(rename("html_inline.html"))
+        .pipe(dest('dist/'));
+});
+

--- a/html/package.json
+++ b/html/package.json
@@ -14,7 +14,8 @@
     "start": "webpack-dev-server",
     "build": "NODE_ENV=production webpack && gulp",
     "check": "gts check",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "customHTML": "NODE_ENV=production webpack && gulp customHTML"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
I added the command customHTML to allow generation of inlined version of index.html called html_inline.html.
This is useful for -I, --index parameter.