### PR TITLE
Add functionality to write to a temp file through url arguments

### DIFF
--- a/man/ttyd.1
+++ b/man/ttyd.1
@@ -64,6 +64,10 @@ Cross platform: macOS, Linux, FreeBSD/OpenBSD, OpenWrt/LEDE, Windows
 \[la]http://localhost:7681?arg=foo&arg=bar\[ra])
 
 .PP
+\-f, \-\-arg\-file
+      Allow client to write URL arguments to a temporary file; the file name is then passed in as a command line argument
+
+.PP
 \-R, \-\-readonly
       Do not allow clients to write to the TTY
 

--- a/man/ttyd.man.md
+++ b/man/ttyd.man.md
@@ -40,6 +40,9 @@ ttyd 1 "September 2016" ttyd "User Manual"
   -a, --url-arg
       Allow client to send command line arguments in URL (eg: http://localhost:7681?arg=foo&arg=bar)
 
+  -f, --arg-file
+      Allow client to write URL arguments to a temporary file; the file name is then passed in as a command line argument
+
   -R, --readonly
       Do not allow clients to write to the TTY
 

--- a/src/server.c
+++ b/src/server.c
@@ -73,6 +73,7 @@ static const struct option options[] = {
     {"ssl-key", required_argument, NULL, 'K'},
     {"ssl-ca", required_argument, NULL, 'A'},
     {"url-arg", no_argument, NULL, 'a'},
+    {"arg-file", no_argument, NULL, 'f'},
     {"readonly", no_argument, NULL, 'R'},
     {"terminal-type", required_argument, NULL, 'T'},
     {"client-option", required_argument, NULL, 't'},
@@ -86,10 +87,10 @@ static const struct option options[] = {
     {NULL, 0, 0, 0}};
 
 #if LWS_LIBRARY_VERSION_NUMBER < 4000000
-static const char *opt_string = "p:i:c:u:g:s:I:b:6aSC:K:A:Rt:T:Om:oBd:vh";
+static const char *opt_string = "p:i:c:u:g:s:I:b:6afSC:K:A:Rt:T:Om:oBd:vh";
 #endif
 #if LWS_LIBRARY_VERSION_NUMBER >= 4000000
-static const char *opt_string = "p:i:c:u:g:s:I:b:P:6aSC:K:A:Rt:T:Om:oBd:vh";
+static const char *opt_string = "p:i:c:u:g:s:I:b:P:6afSC:K:A:Rt:T:Om:oBd:vh";
 #endif
 
 static void print_help() {
@@ -107,6 +108,7 @@ static void print_help() {
           "    -g, --gid               Group id to run with\n"
           "    -s, --signal            Signal to send to the command when exit it (default: 1, SIGHUP)\n"
           "    -a, --url-arg           Allow client to send command line arguments in URL (eg: http://localhost:7681?arg=foo&arg=bar)\n"
+          "    -f, --arg-file          Allow client to write URL arguments to a temporary file; the file name is then passed in as a command line argument\n"
           "    -R, --readonly          Do not allow clients to write to the TTY\n"
           "    -t, --client-option     Send option to client (format: key=value), repeat to add more options\n"
           "    -T, --terminal-type     Terminal type to report, default: xterm-256color\n"
@@ -321,6 +323,11 @@ int main(int argc, char **argv) {
         break;
       case 'a':
         server->url_arg = true;
+        server->arg_file = false;
+        break;
+      case 'f':
+        server->arg_file = true;
+        server->url_arg = false;
         break;
       case 'R':
         server->readonly = true;
@@ -537,7 +544,8 @@ int main(int argc, char **argv) {
     lwsl_notice("  websocket: %s\n", endpoints.ws);
   }
   if (server->check_origin) lwsl_notice("  check origin: true\n");
-  if (server->url_arg) lwsl_notice("  allow url arg: true\n");
+  if (server->url_arg) lwsl_notice("  allow url arg to cli arg: true\n");
+  if (server->arg_file) lwsl_notice("  allow url arg to tmp file: true\n");
   if (server->readonly) lwsl_notice("  readonly: true\n");
   if (server->max_clients > 0)
     lwsl_notice("  max clients: %d\n", server->max_clients);

--- a/src/server.h
+++ b/src/server.h
@@ -65,6 +65,7 @@ struct server {
   int sig_code;            // close signal
   char sig_name[20];       // human readable signal string
   bool url_arg;            // allow client to send cli arguments in URL
+  bool arg_file;           // allow client to write to a temp file through URL arguments
   bool readonly;           // whether not allow clients to write to the TTY
   bool check_origin;       // whether allow websocket connection from different origin
   int max_clients;         // maximum clients to support


### PR DESCRIPTION
This feature is similar to the existing option that allows url arguments to be passed in as command line arguments. Instead, we create a temporary file in /tmp/ and write the url arguments to this file, separated by newlines.

We can then use this to pass secret values to the running process as command line arguments are easily visible through process status.