### PR TITLE
Fixes #777, rendererType property works as expected

### DIFF
--- a/html/src/components/terminal/index.tsx
+++ b/html/src/components/terminal/index.tsx
@@ -283,8 +283,7 @@ export class Xterm extends Component<Props> {
             this.opened = true;
             fitAddon.fit();
         }
-
-        this.applyOptions(this.props.clientOptions);
+        
         this.doReconnect = this.reconnect;
 
         terminal.focus();


### PR DESCRIPTION
The property was being applied *before* the arguments were passed in from the CLI.

Now the property does not get applied until after the CLI arguments are passed in.

I also checked the other client options and they are still working as expected.