### PR TITLE
Don't use webgl if browser is Safari

### DIFF
--- a/html/src/components/terminal/index.tsx
+++ b/html/src/components/terminal/index.tsx
@@ -216,12 +216,13 @@ export class Xterm extends Component<Props> {
                 return false;
             }
         };
+	const isSafari = navigator.userAgent.indexOf('Safari') >= 0;
 
         const { terminal } = this;
         switch (value) {
             case 'webgl':
                 if (this.webglAddon) return;
-                if (isWebGL2Available()) {
+                if (isWebGL2Available() && !isSafari) {
                     this.webglAddon = new WebglAddon();
                     terminal.loadAddon(this.webglAddon);
                     console.log(`[ttyd] WebGL renderer enabled`);

--- a/html/src/components/terminal/index.tsx
+++ b/html/src/components/terminal/index.tsx
@@ -216,7 +216,7 @@ export class Xterm extends Component<Props> {
                 return false;
             }
         };
-	const isSafari = navigator.userAgent.indexOf('Safari') >= 0;
+        const isSafari = navigator.userAgent.indexOf('Safari') >= 0;
 
         const { terminal } = this;
         switch (value) {


### PR DESCRIPTION
For #780 
I'm not sure we will wait for xtermjs to support/fix webgl2.0.  This is the same way as VSCode to avoid the issue for now.