### PR TITLE
Disable WebGL2 on Safari and iOS

### DIFF
--- a/html/src/components/terminal/index.tsx
+++ b/html/src/components/terminal/index.tsx
@@ -217,11 +217,31 @@ export class Xterm extends Component<Props> {
             }
         };
 
+        const isSafari = () => {
+            // https://stackoverflow.com/questions/9847580
+            if (/constructor/i.test(String(window["HTMLElement"]))) {
+                return true;
+            }
+            if (!window.top["safari"]) {
+                return false;
+            }
+            return String(window.top["safari"].pushNotification) === "[object SafariRemoteNotification]";
+        };
+
+        const isIos = () => {
+            // https://stackoverflow.com/questions/9038625
+            // https://github.com/lancedikson/bowser/issues/329
+            return !!navigator.platform && (
+                /iPad|iPhone|iPod/.test(navigator.platform)
+                || (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1 && !window["MSStream"])
+            );
+        };
+
         const { terminal } = this;
         switch (value) {
             case 'webgl':
                 if (this.webglAddon) return;
-                if (isWebGL2Available()) {
+                if (isWebGL2Available() && !isSafari() && !isIos()) {
                     this.webglAddon = new WebglAddon();
                     terminal.loadAddon(this.webglAddon);
                     console.log(`[ttyd] WebGL renderer enabled`);


### PR DESCRIPTION
Fixes: tsl0922/ttyd#780
Fixes: tsl0922/ttyd#798

This patch is similar to tsl0922/ttyd#785 but with a correct Safari detection code