### PR TITLE
Trying to access to window.top

### DIFF
--- a/html/src/components/terminal/index.tsx
+++ b/html/src/components/terminal/index.tsx
@@ -212,12 +212,18 @@ export class Xterm extends Component<Props> {
         const { overlayAddon } = this;
         const isWebGL2Available = () => {
             try {
+                var win = window;
+                try {
+                    win = window.top;
+                } catch (e) {
+                    console.warn(`[ttyd] can't access to window.top`, e);
+                }
                 const isIos =
                     /iPad|iPhone|iPod/.test(navigator.platform) ||
                     (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1 && !window['MSStream']);
                 const isSafari =
                     /constructor/i.test(String(window['HTMLElement'])) ||
-                    String(window['safari']?.pushNotification) === '[object SafariRemoteNotification]';
+                    String(win['safari']?.pushNotification) === '[object SafariRemoteNotification]';
                 return (
                     !isSafari &&
                     !isIos &&


### PR DESCRIPTION
Following #803

The `safari` object does not exist in `window` if ttyd is running inside an iframe. So we are trying to access `window.top` if possible.

**Note**: not tested, I don't have access to npm environment yet.