### PR TITLE
xterm: enable macbook options key as modifier for copy-and-paste

### DIFF
--- a/html/src/components/app.tsx
+++ b/html/src/components/app.tsx
@@ -21,6 +21,8 @@ const clientOptions = {
 const termOptions = {
     fontSize: 13,
     fontFamily: 'Menlo For Powerline,Consolas,Liberation Mono,Menlo,Courier,monospace',
+    macOptionClickForcesSelection: true,
+    macOptionIsMeta: true,
     theme: {
         foreground: '#d2d2d2',
         background: '#2b2b2b',


### PR DESCRIPTION
Enabling `set -g mouse on` in tmux.conf breaks copy-on-select.
On other keyboard layouts the shift key can be used as modifier for copy-on-select.
This commit enables the xterm options required for using the options key
as modifier for copy-on-select.