### PR TITLE
add INLINE_FONT build variable

### DIFF
--- a/html/src/components/terminal/xterm/index.ts
+++ b/html/src/components/terminal/xterm/index.ts
@@ -378,6 +378,15 @@ export class Xterm {
                 case 'isWindows':
                     if (value) console.log('[ttyd] is windows');
                     break;
+                case 'fontFamily': {
+                    const fontSize = prefs['fontSize'] || '13';
+                    document.fonts.load(`${fontSize}px "${value}"`).then(() => {
+                        console.log(`[ttyd] ${value} loaded`);
+                        terminal.options['fontFamily'] = value;
+                        fitAddon.fit();
+                    });
+                    break;
+                }
                 default:
                     console.log(`[ttyd] option: ${key}=${JSON.stringify(value)}`);
                     if (terminal.options[key] instanceof Object) {

--- a/html/src/components/terminal/xterm/index.ts
+++ b/html/src/components/terminal/xterm/index.ts
@@ -378,15 +378,6 @@ export class Xterm {
                 case 'isWindows':
                     if (value) console.log('[ttyd] is windows');
                     break;
-                case 'fontFamily': {
-                    const fontSize = prefs['fontSize'] || '13';
-                    document.fonts.load(`${fontSize}px "${value}"`).then(() => {
-                        console.log(`[ttyd] ${value} loaded`);
-                        terminal.options['fontFamily'] = value;
-                        fitAddon.fit();
-                    });
-                    break;
-                }
                 default:
                     console.log(`[ttyd] option: ${key}=${JSON.stringify(value)}`);
                     if (terminal.options[key] instanceof Object) {

--- a/html/src/style/index.scss
+++ b/html/src/style/index.scss
@@ -16,3 +16,10 @@ body {
     height: calc(100% - 10px);
   }
 }
+
+@if $inline_font {
+  @font-face {
+    font-family: $inline_font_family;
+    src: url($inline_font_path);
+  }
+}

--- a/html/webpack.config.js
+++ b/html/webpack.config.js
@@ -9,6 +9,17 @@ const TerserPlugin = require('terser-webpack-plugin');
 
 const devMode = process.env.NODE_ENV !== 'production';
 
+const inlineFont = () => {
+    if (process.env.INLINE_FONT != undefined) {
+        additionalData = '$inline_font: true;';
+        additionalData += '$inline_font_path:"' + process.env.INLINE_FONT + '";';
+        additionalData += '$inline_font_family:"' + path.parse(process.env.INLINE_FONT).base.split('.')[0] + '";';
+        return additionalData;
+    } else {
+        return '$inline_font: false;';
+    }
+};
+
 const baseConfig = {
     context: path.resolve(__dirname, 'src'),
     entry: {
@@ -27,7 +38,20 @@ const baseConfig = {
             },
             {
                 test: /\.s?[ac]ss$/,
-                use: [devMode ? 'style-loader' : MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader'],
+                use: [
+                    devMode ? 'style-loader' : MiniCssExtractPlugin.loader,
+                    'css-loader',
+                    {
+                        loader: 'sass-loader',
+                        options: {
+                            additionalData: inlineFont(),
+                        },
+                    },
+                ],
+            },
+            {
+                test: /\.(woff|ttf)/,
+                type: 'asset/inline',
             },
         ],
     },


### PR DESCRIPTION
Similar to the use case described in https://github.com/tsl0922/ttyd/issues/318 and https://github.com/tsl0922/ttyd/issues/31 I am using ttyd to share a tmux session for pair programming. I also use a custom nerdfont with icon glyphs which I want all clients to get automatically for a seamless pairing experience. Following the advice in those issues I've been building my own html file and using the `--index` option. However this still requires maintaining my own small fork of ttyd and I wanted to try and upstream something.

To cater to this use case I added an `INLINE_FONT` environment variable to the build allowing a user to pass the path to a font they want inlined in their html file. It works by injecting a css font-face rule if the variable is present. I use the font's file name as the font-family - I'll admit I don't have the deepest understanding of font names and css font-family so this may not be the most robust solution but it is working for me and the few fonts I tried.

With the css rule added I also need to update the webpack configuration to inline any fonts it encounters.

~~The final change required was an additional case to the terminal applyOptions function to load the font and resize the terminal after doing so. This ensures the font is properly applied for a brand new client.~~ This used to be necessary but upon re-testing it isn't anymore. Likely an update in xterm.js removed the need for this.

The complete process for process for using ttyd with a custom font then becomes:
1. Build your own html using the `INLINE_FONT` environment variable
2. Use ttyd with the `--index` option passing your html file and `--client-option fontFamily=` with the font you inlined

If this PR is accepted then we could add this information to the wiki.