### PR TITLE
pty.c: Fix errant use of fcntl F_SETFD

### DIFF
--- a/src/pty.c
+++ b/src/pty.c
@@ -470,7 +470,7 @@ int pty_spawn(pty_process *process, pty_read_cb read_cb, pty_exit_cb exit_cb) {
     status = -errno;
     goto error;
   }
-  if (fcntl(master, F_SETFD, flags | O_NONBLOCK) == -1) {
+  if (fcntl(master, F_SETFL, flags | O_NONBLOCK) == -1) {
     status = -errno;
     goto error;
   }


### PR DESCRIPTION
When this was added in https://github.com/tsl0922/ttyd/commit/cfd338ea5e1a3c3023acade45980b3024c41e507

We before this time the *File descriptor flags* (`F_GETFD`/`F_SETFD`) were augmented to include `FD_CLOEXEC`
Then at this time the additional code added the *File status flags* (`F_GETFL`/`F_SETFL`) to include `O_NONBLOCK`, but this was weaved through code working with `F_SETFD` instead of `F_SETFL`. Some systems may use one big status word for all of them. Mine certainly dont.

FIXES #733