### PR TITLE
Avoid crash on resize message if process has exited

### DIFF
--- a/src/protocol.c
+++ b/src/protocol.c
@@ -314,6 +314,7 @@ int callback_tty(struct lws *wsi, enum lws_callback_reasons reason, void *user, 
           }
           break;
         case RESIZE_TERMINAL:
+          if (pss->process == NULL) break;
           json_object_put(
               parse_window_size(pss->buffer + 1, pss->len - 1, &pss->process->columns, &pss->process->rows));
           pty_resize(pss->process);


### PR DESCRIPTION
Hi, after the 1.7.1 release we were still observing a rare segmentation fault in our ttyd-based application (about 10 crashes per day out of several hundred clients).

I was able to trace it back to a situation where a `RESIZE_TERMINAL` message is received, but the child process has already exited and the `pss->process` struct has been freed. In that case, the `cols` / `row` pointers into the struct still get dereferenced [here](https://github.com/tsl0922/ttyd/blob/45ef5784c168ff42b66fd6556f127c306c471027/src/protocol.c#L43-L44), causing a segmentation fault. I haven't able to replicate this crash in a local development environment, so I suspect network latency is required for this to happen.

With this patch, `RESIZE_TERMINAL` messages just get ignored if the process has been freed, avoiding the issue. This is basically the same as these checks, which are already being done for [`PAUSE`](https://github.com/tsl0922/ttyd/blob/main/src/pty.c#L121) and [`RESUME`](https://github.com/tsl0922/ttyd/blob/main/src/pty.c#L127) messages.

We've been running this patch in production for 4 days now and have no longer experienced any crashes since then. In our version, I'm also logging when this new `if (pss->process == NULL)` conditional runs, and it is now hit about 10 times per day. So I'm fairly sure that this fixes the original cause of the crashes.