### PR TITLE
Add `className` to terminal overlay

### DIFF
--- a/html/src/components/terminal/overlay.ts
+++ b/html/src/components/terminal/overlay.ts
@@ -9,6 +9,7 @@ export class OverlayAddon implements ITerminalAddon {
 
     constructor() {
         this.overlayNode = document.createElement('div');
+        this.overlayNode.className = 'term-overlay';
         this.overlayNode.style.cssText = `border-radius: 15px;
 font-size: xx-large;
 opacity: 0.75;


### PR DESCRIPTION
This PR adds a `className` to the terminal overlay to allow accessing the
overlay without referring to the parent element and inspecting the children.

I would like this for my project since I want to hide the overlay immediately.
Currently, I am checking whether there are 3 children on `.xterm` and deleting
the last element but this would be much nicer to be able to delete the
`.term-overlay` directly.

Another alternative that could work is if you could launch `ttyd` with an option
to prevent any overlays from showing up, i.e. `ttyd --no-overlays`.
