### PR TITLE
Snap created and ready for publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ brew install ttyd
 ## Install on Linux
 
 - Binary version (recommended): download from the [releases](https://github.com/tsl0922/ttyd/releases) page.
+
+- Install the snap:
+    
+    `sudo snap install ttyd --classic`
+    
+    
 - Build from source (debian/ubuntu):
 
     ```bash

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,6 +49,7 @@ parts:
       - extra-cmake-modules
       - git
       - gcc-10
+      - libpthread-stubs0-dev
       
     stage-packages:
       - build-essential 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,6 +45,8 @@ parts:
       - build-essential 
       - libjson-c-dev 
       - libwebsockets-dev
+      - cmake
+      - git
       
     stage-packages:
       - build-essential 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,6 +46,7 @@ parts:
       - libjson-c-dev 
       - libwebsockets-dev
       - cmake
+      - extra-cmake-modules
       - git
       - gcc-10
       

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,14 +28,10 @@ parts:
   ttyd:
     source: https://github.com/tsl0922/ttyd
     source-type: git
-    plugin: nil
-    override-build: |
-      git clone https://github.com/tsl0922/ttyd.git
-      cd ttyd && mkdir build && cd build
-      cmake ..
-      make && make -j$(nproc) install
-      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/bin/  
-      cp ttyd $SNAPCRAFT_PART_INSTALL/usr/bin/
+    plugin: cmake
+    cmake-parameters:
+      - -LDFLAGS='-pthread'
+      - -DCMAKE_INSTALL_PREFIX=/usr
       
     override-pull: |
       snapcraftctl pull

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,8 +28,9 @@ parts:
   ttyd:
     source: https://github.com/tsl0922/ttyd
     source-type: git
-    plugin: cmake
-
+    plugin: make
+    make-parameters:
+      - -lpthread
     override-pull: |
       snapcraftctl pull
       snapcraftctl set-version "$(git describe --tags | sed 's/^v//' | cut -d "-" -f1)"
@@ -38,9 +39,6 @@ parts:
       - build-essential 
       - libjson-c-dev 
       - libwebsockets-dev
-      - cmake
-      - git     
-      - libpthread-stubs0-dev
       
     stage-packages:
       - build-essential 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,11 +40,13 @@ parts:
       - build-essential 
       - libjson-c-dev 
       - libwebsockets-dev
+      - cmake
+      - git      
       
     stage-packages:
       - build-essential 
       - libjson-c-dev 
-      - libwebsockets-dev    
+      - libwebsockets-dev
       
   homeishome-launch:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,6 +37,11 @@ parts:
       - libjson-c-dev 
       - libwebsockets-dev
       
+    stage-packages:
+      - build-essential 
+      - libjson-c-dev 
+      - libwebsockets-dev    
+      
   homeishome-launch:
     plugin: nil
     stage-snaps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,14 +19,14 @@ apps:
     command: usr/bin/ttyd
     command-chain: 
       - bin/homeishome-launch       
-    plugs:
-      - network
-      - network-observe
-      - home
-      - process-control
-      - removable-media
-      - system-observe
-      - system-trace
+#    plugs:
+#      - network
+#      - network-observe
+#      - home
+#      - process-control
+#      - removable-media
+#      - system-observe
+#      - system-trace
 
 parts:
   ttyd:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,9 +28,15 @@ parts:
   ttyd:
     source: https://github.com/tsl0922/ttyd
     source-type: git
-    plugin: cmake
-    cmake-parameters:
-      - -lpthread
+    plugin: nil
+    override-build: |
+      git clone https://github.com/tsl0922/ttyd.git
+      cd ttyd && mkdir build && cd build
+      cmake ..
+      make && sudo make install
+      mkdir -p $SNAPCRAFT_PART_INSTALL/bin/  
+      cp ttyd $SNAPCRAFT_PART_INSTALL/bin/
+      
     override-pull: |
       snapcraftctl pull
       snapcraftctl set-version "$(git describe --tags | sed 's/^v//' | cut -d "-" -f1)"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,8 +30,9 @@ parts:
     source-type: git
     plugin: cmake
     cmake-parameters:
-      - -LDFLAGS=pthread
       - -DCMAKE_INSTALL_PREFIX=/usr
+    build-environment:
+      - LDFLAGS: "-pthread"
       
     override-pull: |
       snapcraftctl pull

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,8 +4,8 @@ summary: Share your terminal over the web
 description: |
  ttyd is a simple command-line tool for sharing terminal over the web
 
-grade: stable
-confinement: strict
+grade: devel
+confinement: devmode
 base: core20
 compression: lzo
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,7 +40,7 @@ parts:
       - libwebsockets-dev
       - cmake
       - git     
-      - libpthreadpool-dev
+      - libpthread-stubs0-dev
       
     stage-packages:
       - build-essential 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,7 @@ assumes:
 
 apps:
   ttyd:
-    command: bin/ttyd
+    command: usr/bin/ttyd
     command-chain: 
       - bin/homeishome-launch       
     plugs:
@@ -33,9 +33,9 @@ parts:
       git clone https://github.com/tsl0922/ttyd.git
       cd ttyd && mkdir build && cd build
       cmake ..
-      make && sudo make install
-      mkdir -p $SNAPCRAFT_PART_INSTALL/bin/  
-      cp ttyd $SNAPCRAFT_PART_INSTALL/bin/
+      make -j$(nproc) && make install
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/bin/  
+      cp ttyd $SNAPCRAFT_PART_INSTALL/usr/bin/
       
     override-pull: |
       snapcraftctl pull

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,10 @@ apps:
       - network
       - network-observe
       - home
+      - process-control
+      - removable-media
+      - system-observe
+      - system-trace
 
 parts:
   ttyd:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,6 +47,7 @@ parts:
       - libwebsockets-dev
       - cmake
       - git
+      - gcc-10
       
     stage-packages:
       - build-essential 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,6 +31,10 @@ parts:
     plugin: cmake
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
+
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version "$(git describe --tags | sed 's/^v//' | cut -d "-" -f1)"
       
     build-packages:
       - build-essential 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: Share your terminal over the web
 description: |
  ttyd is a simple command-line tool for sharing terminal over the web
 
-grade: devel
+grade: stable
 confinement: classic
 base: core20
 compression: lzo
@@ -19,14 +19,6 @@ apps:
     command: usr/bin/ttyd
     command-chain: 
       - bin/homeishome-launch       
-#    plugs:
-#      - network
-#      - network-observe
-#      - home
-#      - process-control
-#      - removable-media
-#      - system-observe
-#      - system-trace
 
 parts:
   ttyd:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,16 +19,11 @@ apps:
     command: usr/bin/ttyd
     command-chain: 
       - bin/homeishome-launch       
-  plugs:
-    - process-control
-    - system-observe
-    - mount-observe
-    - network
-    - network-observe
-    - home
-    - removable-media
-    - mount-observe
-    
+    plugs:
+      - network
+      - network-observe
+      - home
+
 parts:
   ttyd:
     source: https://github.com/tsl0922/ttyd

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,46 @@
+name: ttyd
+adopt-info: ttyd
+summary: Share your terminal over the web
+description: |
+ ttyd is a simple command-line tool for sharing terminal over the web
+
+grade: stable
+confinement: strict
+base: core20
+compression: lzo
+
+license: MIT
+
+assumes:
+  - command-chain
+
+apps:
+  ttyd:
+    command: bin/ttyd
+    command-chain: 
+      - bin/homeishome-launch       
+  plugs:
+    - process-control
+    - system-observe
+    - mount-observe
+    - network
+    - network-observe
+    - home
+    - removable-media
+    - mount-observe
+    
+parts:
+  ttyd:
+    source: https://github.com/tsl0922/ttyd
+    source-type: git
+    plugin: cmake
+    
+    build-packages:
+      - build-essential 
+      - libjson-c-dev 
+      - libwebsockets-dev
+      
+  homeishome-launch:
+    plugin: nil
+    stage-snaps:
+      - homeishome-launch  

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,7 @@ assumes:
 
 apps:
   ttyd:
-    command: usr/bin/ttyd
+    command: bin/ttyd
     command-chain: 
       - bin/homeishome-launch       
     plugs:
@@ -29,8 +29,6 @@ parts:
     source: https://github.com/tsl0922/ttyd
     source-type: git
     plugin: cmake
-    cmake-parameters:
-      - -DCMAKE_INSTALL_PREFIX=/usr
 
     override-pull: |
       snapcraftctl pull

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,7 @@ assumes:
 
 apps:
   ttyd:
-    command: bin/ttyd
+    command: usr/bin/ttyd
     command-chain: 
       - bin/homeishome-launch       
   plugs:
@@ -34,7 +34,9 @@ parts:
     source: https://github.com/tsl0922/ttyd
     source-type: git
     plugin: cmake
-    
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      
     build-packages:
       - build-essential 
       - libjson-c-dev 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,8 +28,8 @@ parts:
   ttyd:
     source: https://github.com/tsl0922/ttyd
     source-type: git
-    plugin: make
-    make-parameters:
+    plugin: cmake
+    cmake-parameters:
       - -lpthread
     override-pull: |
       snapcraftctl pull

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,7 +39,8 @@ parts:
       - libjson-c-dev 
       - libwebsockets-dev
       - cmake
-      - git      
+      - git     
+      - libpthreadpool-dev
       
     stage-packages:
       - build-essential 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,7 +33,7 @@ parts:
       git clone https://github.com/tsl0922/ttyd.git
       cd ttyd && mkdir build && cd build
       cmake ..
-      make -j$(nproc) && make install
+      make && make -j$(nproc) install
       mkdir -p $SNAPCRAFT_PART_INSTALL/usr/bin/  
       cp ttyd $SNAPCRAFT_PART_INSTALL/usr/bin/
       

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,11 +41,6 @@ parts:
       - build-essential 
       - libjson-c-dev 
       - libwebsockets-dev
-      - cmake
-      - extra-cmake-modules
-      - git
-      - gcc-10
-      - libpthread-stubs0-dev
       
     stage-packages:
       - build-essential 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,7 +5,7 @@ description: |
  ttyd is a simple command-line tool for sharing terminal over the web
 
 grade: devel
-confinement: devmode
+confinement: classic
 base: core20
 compression: lzo
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,7 +30,7 @@ parts:
     source-type: git
     plugin: cmake
     cmake-parameters:
-      - -LDFLAGS='-pthread'
+      - -LDFLAGS=pthread
       - -DCMAKE_INSTALL_PREFIX=/usr
       
     override-pull: |


### PR DESCRIPTION
Hi, 

I've recently created a snap for ttyd and have it working with classic confinement. Meaning it will run "as native" within a snap container for any Linux distro supporting `snapd`. Learn more about snaps [here](https://snapcraft.io/about). 

I am happy to maintain the snap for your project, unless you'd prefer maintaining it all "in-house". There's not much anyone on the team would have to do, as the snaps are automatically built and published on the snap [store](https://snapcraft.io/store). 

As part of the security checks, pedigree, and validation, the upstream team/devs should at least know about it and agree with the publication as a `classic` snap. Basically, the snap will much like a `.deb` or `.rpm` on another distro supporting those packages; except it's distro agnostic. 

I hope this comes as a welcome PR. If you'd like to be involved in the convo with the snapcraft team, please see this [thread](https://forum.snapcraft.io/t/classic-confinement-for-ttyd/31583/7). 