### PR TITLE
Bump CMake version to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
     project(ttyd C) 


### PR DESCRIPTION
Fixes the following warning:

Compatibility with CMake < 2.8.12 will be removed from a future version of CMake.