### PR TITLE
Increase info.max_http_header_data to max value of 65535

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -321,7 +321,7 @@ int main(int argc, char **argv) {
 #ifndef LWS_WITHOUT_EXTENSIONS
   info.extensions = extensions;
 #endif
-  info.max_http_header_data = 20480;
+  info.max_http_header_data = 65535;
 
   int debug_level = LLL_ERR | LLL_WARN | LLL_NOTICE;
   char iface[128] = "";


### PR DESCRIPTION
I would like to increase info.max_http_header_data to 65535 to resolve issues when you have to deal with large http headers.
