### PR TITLE
Leverage Docker Layer System

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 FROM ubuntu:20.04
 
 ARG TARGETARCH
-COPY ./dist/${TARGETARCH}/ttyd /usr/bin/ttyd
+
+# Dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends tini && rm -rf /var/lib/apt/lists/*
+
+# Application
+COPY ./dist/${TARGETARCH}/ttyd /usr/bin/ttyd
 
 EXPOSE 7681
 WORKDIR /root

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,8 +1,12 @@
 FROM alpine
 
 ARG TARGETARCH
-COPY ./dist/${TARGETARCH}/ttyd /usr/bin/ttyd
+
+# Dependencies
 RUN apk add --no-cache bash tini
+
+# Application
+COPY ./dist/${TARGETARCH}/ttyd /usr/bin/ttyd
 
 EXPOSE 7681
 WORKDIR /root


### PR DESCRIPTION
Dockerfile best practices recommend to move the installation of external dependencies before specific code. This will improve local development experience by improving Docker cache management and it will improve final Docker images compaction by sharing the first layers.