### PR TITLE
Addressing dev packages in staging - reduce size of snap - also added workflow

### DIFF
--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -1,0 +1,28 @@
+name: 🧪 Test snap can be built on x86_64
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+        
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: snapcore/action-build@v1
+        id: build
+
+      - uses: diddlesnaps/snapcraft-review-action@v1
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          isClassic: 'true'
+          # Plugs and Slots declarations to override default denial (requires store assertion to publish)
+          # plugs: ./plug-declaration.json
+          # slots: ./slot-declaration.json

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,9 +40,8 @@ parts:
       - libwebsockets-dev
       
     stage-packages:
-      - build-essential 
-      - libjson-c-dev 
-      - libwebsockets-dev
+      - libjson-c4
+      - libwebsockets15
       
   homeishome-launch:
     plugin: nil


### PR DESCRIPTION
Removed all dev packages from staging in snap. Size now 761KB. Reference https://github.com/tsl0922/ttyd/issues/1253 
```
snap info ttyd
---
~~~ truncated ~~~
---
installed:          1.7.4             (x3) 761kB classic
```
Also added `test-snap-can-build` workflow for quick test against any commits that may pose a problem for snap builds.