### PR TITLE
Overwrite ClientOptions with url query params

### DIFF
--- a/html/src/components/app.tsx
+++ b/html/src/components/app.tsx
@@ -1,8 +1,9 @@
 import { h, Component } from 'preact';
 
-import { ITerminalOptions, ITheme } from '@xterm/xterm';
-import { ClientOptions, FlowControl } from './terminal/xterm';
 import { Terminal } from './terminal';
+
+import type { ITerminalOptions, ITheme } from '@xterm/xterm';
+import type { ClientOptions, FlowControl } from './terminal/xterm';
 
 const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
 const path = window.location.pathname.replace(/[/]+$/, '');

--- a/html/src/components/terminal/xterm/index.ts
+++ b/html/src/components/terminal/xterm/index.ts
@@ -357,7 +357,6 @@ export class Xterm {
 
     @bind
     private applyPreferences(prefs: Preferences) {
-        console.log(prefs);
         const { terminal, fitAddon, register } = this;
         if (prefs.enableZmodem || prefs.enableTrzsz) {
             this.zmodemAddon = new ZmodemAddon({

--- a/html/src/components/terminal/xterm/index.ts
+++ b/html/src/components/terminal/xterm/index.ts
@@ -304,7 +304,6 @@ export class Xterm {
             new URLSearchParams(window.location.search) as unknown as Iterable<[string, string]>
         );
         for (const [k, queryVal] of queryObj) {
-            console.log(k, queryVal);
             if (queryVal === null) {
                 continue;
             }

--- a/html/tsconfig.json
+++ b/html/tsconfig.json
@@ -10,6 +10,7 @@
     "declaration": false,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    "lib": ["es2019", "dom"],
   },
   "include": [
     "src/**/*.tsx",


### PR DESCRIPTION
https://github.com/tsl0922/ttyd/issues/1270

This PR enables ttyd to read ClientOption settings from url and overwrite server configuration.
Added support for the following options:
    - rendererType
    - disableLeaveAlert
    - disableResizeOverlay
    - disableReconnect
    - enableZmodem
    - enableTrzsz
    - trzszDragInitTimeout
    - enableSixel
    - titleFixed
    - isWindows
    - unicodeVersion

Here is a working demo:

https://github.com/tsl0922/ttyd/assets/1357073/ff17e8b5-ac72-4760-9f98-cc590cdb29be

