### PR TITLE
ADD two factor authentication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
     set(CMAKE_C_STANDARD 99)
 endif()
 
-set(SOURCE_FILES src/utils.c src/pty.c src/protocol.c src/http.c src/server.c)
+set(SOURCE_FILES src/totp.c src/utils.c src/pty.c src/protocol.c src/http.c src/server.c)
 
 include(FindPackageHandleStandardArgs)
 
@@ -79,6 +79,8 @@ else()
         list(APPEND LINK_LIBS util)
     endif()
 endif()
+
+list(APPEND LINK_LIBS m)
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 target_include_directories(${PROJECT_NAME} PUBLIC ${INCLUDE_DIRS})

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ ttyd is a simple command-line tool for sharing terminal over the web.
 - SSL support based on [OpenSSL](https://www.openssl.org) / [Mbed TLS](https://github.com/Mbed-TLS/mbedtls)
 - Run any custom command with options
 - Basic authentication support and many other custom options
+- Two-factor authentication (2FA) in which the TOTP code is appended to the password
 - Cross platform: macOS, Linux, FreeBSD/OpenBSD, [OpenWrt](https://openwrt.org), Windows
 
 > ❤ Special thanks to [JetBrains](https://www.jetbrains.com/?from=ttyd) for sponsoring the opensource license to this project.
@@ -69,6 +70,7 @@ OPTIONS:
     -i, --interface         Network interface to bind (eg: eth0), or UNIX domain socket path (eg: /var/run/ttyd.sock)
     -U, --socket-owner      User owner of the UNIX domain socket file, when enabled (eg: user:group)
     -c, --credential        Credential for basic authentication (format: username:password)
+    -1, --totp              Time-based one-time password secret (format: [DIGEST:]SECRET[:DIGITS[:INTERVAL[:OFFSET]]])
     -H, --auth-header       HTTP Header name for auth proxy, this will configure ttyd to let a HTTP reverse proxy handle authentication
     -u, --uid               User id to run with
     -g, --gid               Group id to run with

--- a/man/ttyd.1
+++ b/man/ttyd.1
@@ -54,6 +54,10 @@ Cross platform: macOS, Linux, FreeBSD/OpenBSD, OpenWrt/LEDE, Windows
       Credential for Basic Authentication (format: username:password)
 
 .PP
+-1, --totp [DIGEST:]SECRET[:DIGITS[:INTERVAL[:OFFSET]]]
+      Time-based one-time password secret (format: [DIGEST:]SECRET[:DIGITS[:INTERVAL[:OFFSET]]])
+
+.PP
 -H, --auth-header 
       HTTP Header name for auth proxy, this will configure ttyd to let a HTTP reverse proxy handle authentication
 

--- a/man/ttyd.man.md
+++ b/man/ttyd.man.md
@@ -32,6 +32,9 @@ ttyd 1 "September 2016" ttyd "User Manual"
   -c, --credential USER[:PASSWORD]
       Credential for Basic Authentication (format: username:password)
 
+  -1, --totp [DIGEST:]SECRET[:DIGITS[:INTERVAL[:OFFSET]]]
+      Time-based one-time password secret (format: [DIGEST:]SECRET[:DIGITS[:INTERVAL[:OFFSET]]])
+
   -H, --auth-header <name>
       HTTP Header name for auth proxy, this will configure ttyd to let a HTTP reverse proxy handle authentication
 

--- a/src/server.h
+++ b/src/server.h
@@ -65,6 +65,9 @@ struct server {
   int client_count;        // client count
   char *prefs_json;        // client preferences
   char *credential;        // encoded basic auth credential
+  char *credential_dec;    // decoded basic auth credential
+  char *totp;              // time-based one-time password secret
+  char last_totp_code[16]; // last-used TOTP code, max 8 digits + NUL
   char *auth_header;       // header name used for auth proxy
   char *index;             // custom index.html
   char *command;           // full command line

--- a/src/totp.c
+++ b/src/totp.c
@@ -1,0 +1,167 @@
+#include "totp.h"
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <strings.h>  /* for strcasecmp */
+#include <time.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <math.h>
+
+static const char *BASE32_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+/*
+ * Decode Base32 (no padding) into a dynamically allocated buffer.
+ * *out_len will be set to the byte‐length of the result.
+ * Returns 0 on success, -1 on failure.
+ */
+static int base32_decode(const char *in, uint8_t **out, size_t *out_len) {
+  size_t i, bitbuf = 0, bits = 0;
+  size_t in_len = strlen(in);
+  uint8_t *buf = malloc(in_len * 5 / 8 + 1);
+  if (!buf) return -1;
+  *out_len = 0;
+
+  for (i = 0; i < in_len; i++) {
+    char c = toupper((unsigned char)in[i]);
+    const char *p = strchr(BASE32_CHARS, c);
+    if (!p) break;  /* stop at first invalid char */
+
+    bitbuf = (bitbuf << 5) | (p - BASE32_CHARS);
+    bits += 5;
+    if (bits >= 8) {
+      bits -= 8;
+      buf[*out_len] = (uint8_t)(bitbuf >> bits);
+      (*out_len)++;
+      bitbuf &= ((1 << bits) - 1);
+    }
+  }
+  *out = buf;
+  return 0;
+}
+
+int TOTP_Generate(const char *base32_secret,
+                  const EVP_MD *md,
+                  uint64_t t,
+                  int digits,
+                  uint64_t interval,
+                  int64_t t0,
+                  char *out,
+                  size_t out_len)
+{
+  if (!base32_secret || !md || !out || out_len < (size_t)digits + 1)
+    return -1;
+
+  /* 1) decode the shared secret */
+  uint8_t *key = NULL;
+  size_t key_len = 0;
+  if (base32_decode(base32_secret, &key, &key_len) < 0)
+    return -1;
+
+  /* 2) compute time‐step counter */
+  uint64_t steps = (t - t0) / interval;
+
+  /* 3) 8‐byte big‐endian counter */
+  uint8_t msg[8];
+  for (int i = 0; i < 8; i++)
+    msg[7 - i] = (uint8_t)(steps >> (i * 8));
+
+  /* 4) HMAC(hash, key, msg) */
+  unsigned char hmac[EVP_MAX_MD_SIZE];
+  unsigned int hmac_len = 0;
+  if (!HMAC(md, key, (int)key_len, msg, sizeof(msg), hmac, &hmac_len)) {
+    free(key);
+    return -1;
+  }
+  free(key);
+
+  /* 5) dynamic truncation */
+  int offset = hmac[hmac_len - 1] & 0x0F;
+  uint32_t bin =
+    ((hmac[offset + 0] & 0x7F) << 24) |
+    ((hmac[offset + 1] & 0xFF) << 16) |
+    ((hmac[offset + 2] & 0xFF) <<  8) |
+    ((hmac[offset + 3] & 0xFF) <<  0);
+
+  /* 6) compute OTP value */
+  uint32_t otp = bin % (uint32_t)pow(10, digits);
+
+  /* 7) format zero-padded result into out[] */
+  char fmt[8];
+  snprintf(fmt, sizeof(fmt), "%%0%dd", digits);
+  snprintf(out, out_len, fmt, otp);
+  return 0;
+}
+
+int TOTP_GenerateFromSpec(const char *spec,
+                          time_t t,
+                          char *out,
+                          size_t out_len)
+{
+  if (!spec || !out) return -1;
+
+  /* make a writable copy */
+  char *buf = strdup(spec);
+  if (!buf) return -1;
+
+  const EVP_MD *md = EVP_sha1();
+  char *secret = NULL;
+
+  /* tokenize on ':' */
+  char *saveptr = NULL;
+  char *token = strtok_r(buf, ":", &saveptr);
+  if (!token) {
+    free(buf);
+    return -1;
+  }
+
+  /* first token may be the digest name */
+  if (strcasecmp(token, "sha1") == 0) {
+    md = EVP_sha1();
+    token = strtok_r(NULL, ":", &saveptr);
+  }
+  else if (strcasecmp(token, "sha256") == 0) {
+    md = EVP_sha256();
+    token = strtok_r(NULL, ":", &saveptr);
+  }
+  else if (strcasecmp(token, "sha512") == 0) {
+    md = EVP_sha512();
+    token = strtok_r(NULL, ":", &saveptr);
+  }
+  else {
+    /* no digest prefix, first token is the secret */
+  }
+
+  if (!token) {          /* must have at least SECRET */
+    free(buf);
+    return -1;
+  }
+  secret = token;
+
+  /* optional fields */
+  int      digits   = 6;
+  uint64_t interval = 30;
+  int64_t  offset   = 0;
+
+  token = strtok_r(NULL, ":", &saveptr);
+  if (token) digits = atoi(token);
+
+  token = strtok_r(NULL, ":", &saveptr);
+  if (token) interval = strtoull(token, NULL, 10);
+
+  token = strtok_r(NULL, ":", &saveptr);
+  if (token) offset = strtoll(token, NULL, 10);
+
+  /* call the core generator */
+  int rc = TOTP_Generate(secret,
+                         md,
+                         t,
+                         digits,
+                         interval,
+                         offset,
+                         out,
+                         out_len);
+
+  free(buf);
+  return rc;
+}

--- a/src/totp.h
+++ b/src/totp.h
@@ -1,0 +1,49 @@
+#ifndef TOTP_H
+#define TOTP_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <time.h>
+#include <openssl/evp.h>
+
+/*
+ * TOTP_Generate()
+ *
+ * base32_secret: ASCII Base32-encoded shared secret (no padding).
+ * md:            hash algorithm, e.g. EVP_sha1(), EVP_sha256(), EVP_sha512().
+ * t:             current Unix time (seconds), e.g. time(NULL).
+ * digits:        number of digits in OTP (usually 6,7 or 8).
+ * interval:      time step in seconds (usually 30).
+ * t0:            epoch offset (usually 0).
+ * out:           buffer to receive \0-terminated OTP string.
+ * out_len:       size of out[]; must be ≥ digits+1.
+ *
+ * Returns 0 on success (out contains the zero-padded OTP), or –1 on error.
+ */
+int TOTP_Generate(const char *base32_secret,
+                  const EVP_MD *md,
+                  uint64_t t,
+                  int digits,
+                  uint64_t interval,
+                  int64_t t0,
+                  char *out,
+                  size_t out_len);
+
+
+/*
+ * Parse a specifier of the form
+ *   [DIGEST:]SECRET[:DIGITS[:INTERVAL[:OFFSET]]]
+ * and generate the OTP for time t.
+ *
+ * spec:    the specification string, see above
+ * t:       current Unix time (e.g. time(NULL))
+ * out:     must be at least (digits+1) bytes
+ * out_len: length of out[]
+ *
+ * Returns 0 on success, -1 on error.
+ */
+int TOTP_GenerateFromSpec(const char *spec,
+                          time_t t,
+                          char *out,
+                          size_t out_len);
+#endif /* TOTP_H */


### PR DESCRIPTION
Enable two-factor authentication (2FA) by creating a password that combines the value from the --credential option with the TOTP generated using the secret specified by the --totp option.