### PR TITLE
add macos and win64 to release static builds

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [i686, x86_64, arm, armhf, aarch64, mips, mipsel, mips64, mips64el, s390x, win32]
+        target: [i686, x86_64, arm, armhf, aarch64, mips, mipsel, mips64, mips64el, s390x, win32, win64]
     steps:
       - uses: actions/checkout@v4
       - name: Install packages
@@ -37,3 +37,29 @@ jobs:
           name: ttyd.${{ matrix.target }}
           path: build/ttyd*
 
+  macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: macos-13
+          - arch: arm64
+            runner: macos-14
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          brew install cmake json-c libwebsockets libuv openssl
+      - name: Build macOS binary (${{ matrix.arch }})
+        run: |
+          mkdir build && cd build
+          cmake -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} \
+                ..
+          make -j$(sysctl -n hw.ncpu)
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ttyd.macos.${{ matrix.arch }}
+          path: build/ttyd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
   publish:
     needs: [build]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Check version bump
@@ -22,12 +24,17 @@ jobs:
             exit 1
           fi
       - uses: actions/download-artifact@v4
-      - run: |
-          mkdir build
-          for file in ttyd.*/*; do
-            target=$(echo $file | awk -F/ '{print $1}')
-            [[ $file == *.exe ]] && target="$target.exe"
-            mv $file build/$target
+        with:
+          path: artifacts
+      - name: Prepare release assets
+        run: |
+          mkdir -p build
+          for file in artifacts/ttyd.*/ttyd*; do
+            if [ -f "$file" ]; then
+              target=$(echo $file | awk -F'/' '{print $2}' | sed 's/ttyd\.//')
+              [[ $file == *.exe ]] && ext=".exe" || ext=""
+              mv "$file" "build/ttyd.$target$ext"
+            fi
           done
           pushd build; sha256sum ttyd.* > SHA256SUMS; popd
       - uses: ncipollo/release-action@v1
@@ -35,3 +42,31 @@ jobs:
           artifacts: build/*
           allowUpdates: true
           draft: true
+          generateReleaseNotes: true
+          name: 'ttyd v${{ github.ref_name }}'
+          body: |
+            ## Release ${{ github.ref_name }}
+
+            ### Available Static Binaries:
+
+            **Linux (musl static):**
+            - `ttyd.i686` - Linux 32-bit (i686)
+            - `ttyd.x86_64` - Linux 64-bit (AMD64)
+            - `ttyd.arm` - Linux ARM 32-bit (EABI)
+            - `ttyd.armhf` - Linux ARM 32-bit (hard-float)
+            - `ttyd.aarch64` - Linux ARM 64-bit
+            - `ttyd.mips` - Linux MIPS (big-endian)
+            - `ttyd.mipsel` - Linux MIPS (little-endian)
+            - `ttyd.mips64` - Linux MIPS 64-bit (big-endian)
+            - `ttyd.mips64el` - Linux MIPS 64-bit (little-endian)
+            - `ttyd.s390x` - Linux IBM S/390
+
+            **macOS:**
+            - `ttyd.macos.x86_64` - macOS Intel (10.15+)
+            - `ttyd.macos.arm64` - macOS Apple Silicon (11.0+)
+
+            **Windows:**
+            - `ttyd.win32.exe` - Windows 32-bit
+            - `ttyd.win64.exe` - Windows 64-bit
+
+            **Verification:** Use `SHA256SUMS` to validate file integrity.

--- a/scripts/cross-build.sh
+++ b/scripts/cross-build.sh
@@ -138,7 +138,7 @@ build() {
     COMPONENTS="1"
     SYSTEM="Linux"
 
-    if [ "$ALIAS" = "win32" ]; then
+    if [ "$ALIAS" = "win32" ] || [ "$ALIAS" = "win64" ]; then
         COMPONENTS=2
         SYSTEM="Windows"
     fi
@@ -185,6 +185,9 @@ case ${BUILD_TARGET} in
         ;;
     win32)
         build x86_64-w64-mingw32 "${BUILD_TARGET}"
+        ;;
+    win64|x86_64-mingw)
+        build x86_64-w64-mingw32 "win64"
         ;;
     *)
         echo "unknown cross target: ${BUILD_TARGET}" && exit 1


### PR DESCRIPTION
While using Homebrew is pretty handy to install ttyd at MacOS I have found scenarios where an static compiled version without depending on all Homebrew libs and system is needed.
I saw an issue requesting this, where you said PRs where welcome. Here is it.
An example output from this change on the release you can see at https://github.com/hectorgarcia-cw/ttyd/releases/tag/1.7.7 (I of course retag latest commit, so no md5 match with 1.7.7 builds)