### PR TITLE
Add outbound websocket client mode (--connect)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,8 @@ build
 # VSCode files
 .vscode/
 
+# Node modules
+node_modules/
+
 # Project files
 !init.d

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,35 @@ add_test(NAME outbound-websocket
     COMMAND node ${CMAKE_SOURCE_DIR}/test/test-outbound.js $<TARGET_FILE:${PROJECT_NAME}>
 )
 
+if(NOT MSVC)
+    # Sanitized build: separate executable with ASan + UBSan
+    add_executable(${PROJECT_NAME}-sanitized ${SOURCE_FILES})
+    target_include_directories(${PROJECT_NAME}-sanitized PUBLIC ${INCLUDE_DIRS})
+    target_link_libraries(${PROJECT_NAME}-sanitized ${LINK_LIBS})
+    target_compile_definitions(${PROJECT_NAME}-sanitized PUBLIC
+        TTYD_VERSION="${TTYD_VERSION}"
+    )
+    target_compile_options(${PROJECT_NAME}-sanitized PRIVATE
+        -fsanitize=address,undefined -fno-omit-frame-pointer -g
+    )
+    target_link_options(${PROJECT_NAME}-sanitized PRIVATE
+        -fsanitize=address,undefined
+    )
+    set_target_properties(${PROJECT_NAME}-sanitized PROPERTIES EXCLUDE_FROM_ALL TRUE)
+
+    add_test(NAME outbound-websocket-sanitized
+        COMMAND node ${CMAKE_SOURCE_DIR}/test/test-outbound.js $<TARGET_FILE:${PROJECT_NAME}-sanitized>
+    )
+
+    # make test-sanitized: build + run tests under ASan/UBSan
+    add_custom_target(test-sanitized
+        COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target ${PROJECT_NAME}-sanitized
+        COMMAND ${CMAKE_CTEST_COMMAND} -R sanitized --output-on-failure
+        DEPENDS ${PROJECT_NAME}-sanitized
+        COMMENT "Running tests with AddressSanitizer + UndefinedBehaviorSanitizer"
+    )
+endif()
+
 include(GNUInstallDirs)
 
 install(TARGETS ${PROJECT_NAME} DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT prog)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,11 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC
     $<$<PLATFORM_ID:Windows>:_WIN32_WINNT=0xa00 WINVER=0xa00>
 )
 
+enable_testing()
+add_test(NAME outbound-websocket
+    COMMAND node ${CMAKE_SOURCE_DIR}/test/test-outbound.js $<TARGET_FILE:${PROJECT_NAME}>
+)
+
 include(GNUInstallDirs)
 
 install(TARGETS ${PROJECT_NAME} DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT prog)

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -404,3 +404,133 @@ int callback_tty(struct lws *wsi, enum lws_callback_reasons reason, void *user, 
 
   return 0;
 }
+
+int callback_tty_client(struct lws *wsi, enum lws_callback_reasons reason, void *user, void *in, size_t len) {
+  struct pss_tty *pss = (struct pss_tty *)user;
+
+  switch (reason) {
+    case LWS_CALLBACK_CLIENT_ESTABLISHED:
+      lwsl_notice("WS client connected to %s\n", server->connect_url);
+      pss->authenticated = true;
+      pss->wsi = wsi;
+      pss->lws_close_status = LWS_CLOSE_STATUS_NOSTATUS;
+
+      if (!spawn_process(pss, 80, 24)) return -1;
+      break;
+
+    case LWS_CALLBACK_CLIENT_WRITEABLE:
+      if (!pss->initialized) {
+        if (pss->initial_cmd_index == sizeof(initial_cmds)) {
+          pss->initialized = true;
+          pty_resume(pss->process);
+          break;
+        }
+        if (send_initial_message(wsi, pss->initial_cmd_index) < 0) {
+          lwsl_err("failed to send initial message, index: %d\n", pss->initial_cmd_index);
+          lws_close_reason(wsi, LWS_CLOSE_STATUS_UNEXPECTED_CONDITION, NULL, 0);
+          return -1;
+        }
+        pss->initial_cmd_index++;
+        lws_callback_on_writable(wsi);
+        break;
+      }
+
+      if (pss->lws_close_status > LWS_CLOSE_STATUS_NOSTATUS) {
+        lws_close_reason(wsi, pss->lws_close_status, NULL, 0);
+        return 1;
+      }
+
+      if (pss->pty_buf != NULL) {
+        wsi_output(wsi, pss->pty_buf);
+        pty_buf_free(pss->pty_buf);
+        pss->pty_buf = NULL;
+        pty_resume(pss->process);
+      }
+      break;
+
+    case LWS_CALLBACK_CLIENT_RECEIVE:
+      if (pss->buffer == NULL) {
+        pss->buffer = xmalloc(len);
+        pss->len = len;
+        memcpy(pss->buffer, in, len);
+      } else {
+        pss->buffer = xrealloc(pss->buffer, pss->len + len);
+        memcpy(pss->buffer + pss->len, in, len);
+        pss->len += len;
+      }
+
+      if (lws_remaining_packet_payload(wsi) > 0 || !lws_is_final_fragment(wsi)) {
+        return 0;
+      }
+
+      {
+        const char command = pss->buffer[0];
+        switch (command) {
+          case INPUT:
+            if (!server->writable) break;
+            if (pss->process == NULL) break;
+            {
+              int err = pty_write(pss->process, pty_buf_init(pss->buffer + 1, pss->len - 1));
+              if (err) {
+                lwsl_err("uv_write: %s (%s)\n", uv_err_name(err), uv_strerror(err));
+                return -1;
+              }
+            }
+            break;
+          case RESIZE_TERMINAL:
+            if (pss->process == NULL) break;
+            json_object_put(
+                parse_window_size(pss->buffer + 1, pss->len - 1, &pss->process->columns, &pss->process->rows));
+            pty_resize(pss->process);
+            break;
+          case PAUSE:
+            if (pss->process != NULL) pty_pause(pss->process);
+            break;
+          case RESUME:
+            if (pss->process != NULL) pty_resume(pss->process);
+            break;
+          default:
+            lwsl_warn("ignored unknown message type: %c\n", command);
+            break;
+        }
+      }
+
+      if (pss->buffer != NULL) {
+        free(pss->buffer);
+        pss->buffer = NULL;
+      }
+      break;
+
+    case LWS_CALLBACK_CLOSED:
+      lwsl_notice("WS client connection closed\n");
+
+      if (pss->buffer != NULL) free(pss->buffer);
+      if (pss->pty_buf != NULL) pty_buf_free(pss->pty_buf);
+
+      if (pss->process != NULL) {
+        ((pty_ctx_t *)pss->process->ctx)->ws_closed = true;
+        if (process_running(pss->process)) {
+          pty_pause(pss->process);
+          lwsl_notice("killing process, pid: %d\n", pss->process->pid);
+          pty_kill(pss->process, server->sig_code);
+        }
+      }
+
+      force_exit = true;
+      lws_cancel_service(context);
+      uv_stop(server->loop);
+      break;
+
+    case LWS_CALLBACK_CLIENT_CONNECTION_ERROR:
+      lwsl_err("WS client connection error: %s\n", in ? (char *)in : "(null)");
+      force_exit = true;
+      lws_cancel_service(context);
+      uv_stop(server->loop);
+      break;
+
+    default:
+      break;
+  }
+
+  return 0;
+}

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -198,6 +198,107 @@ static bool check_auth(struct lws *wsi, struct pss_tty *pss) {
   return true;
 }
 
+// --- shared helpers used by both server and client callbacks ---
+
+static int handle_writeable(struct lws *wsi, struct pss_tty *pss) {
+  if (!pss->initialized) {
+    if (pss->initial_cmd_index == sizeof(initial_cmds)) {
+      pss->initialized = true;
+      pty_resume(pss->process);
+      return 0;
+    }
+    if (send_initial_message(wsi, pss->initial_cmd_index) < 0) {
+      lwsl_err("failed to send initial message, index: %d\n", pss->initial_cmd_index);
+      lws_close_reason(wsi, LWS_CLOSE_STATUS_UNEXPECTED_CONDITION, NULL, 0);
+      return -1;
+    }
+    pss->initial_cmd_index++;
+    lws_callback_on_writable(wsi);
+    return 0;
+  }
+
+  if (pss->lws_close_status > LWS_CLOSE_STATUS_NOSTATUS) {
+    lws_close_reason(wsi, pss->lws_close_status, NULL, 0);
+    return 1;
+  }
+
+  if (pss->pty_buf != NULL) {
+    wsi_output(wsi, pss->pty_buf);
+    pty_buf_free(pss->pty_buf);
+    pss->pty_buf = NULL;
+    pty_resume(pss->process);
+  }
+  return 0;
+}
+
+// Accumulate incoming data into pss->buffer. Returns true when the full message is ready.
+static bool receive_append(struct pss_tty *pss, struct lws *wsi, void *in, size_t len) {
+  if (pss->buffer == NULL) {
+    pss->buffer = xmalloc(len);
+    pss->len = len;
+    memcpy(pss->buffer, in, len);
+  } else {
+    pss->buffer = xrealloc(pss->buffer, pss->len + len);
+    memcpy(pss->buffer + pss->len, in, len);
+    pss->len += len;
+  }
+  return !(lws_remaining_packet_payload(wsi) > 0 || !lws_is_final_fragment(wsi));
+}
+
+// Dispatch common commands (INPUT, RESIZE, PAUSE, RESUME).
+// Returns: 0 = handled, 1 = unknown command, -1 = error.
+static int handle_command(struct pss_tty *pss) {
+  const char command = pss->buffer[0];
+  switch (command) {
+    case INPUT:
+      if (!server->writable) return 0;
+      if (pss->process == NULL) return 0;
+      {
+        int err = pty_write(pss->process, pty_buf_init(pss->buffer + 1, pss->len - 1));
+        if (err) {
+          lwsl_err("uv_write: %s (%s)\n", uv_err_name(err), uv_strerror(err));
+          return -1;
+        }
+      }
+      return 0;
+    case RESIZE_TERMINAL:
+      if (pss->process == NULL) return 0;
+      json_object_put(
+          parse_window_size(pss->buffer + 1, pss->len - 1, &pss->process->columns, &pss->process->rows));
+      pty_resize(pss->process);
+      return 0;
+    case PAUSE:
+      if (pss->process != NULL) pty_pause(pss->process);
+      return 0;
+    case RESUME:
+      if (pss->process != NULL) pty_resume(pss->process);
+      return 0;
+    default:
+      return 1;
+  }
+}
+
+static void receive_cleanup(struct pss_tty *pss) {
+  if (pss->buffer != NULL) {
+    free(pss->buffer);
+    pss->buffer = NULL;
+  }
+}
+
+static void handle_close(struct pss_tty *pss) {
+  if (pss->buffer != NULL) free(pss->buffer);
+  if (pss->pty_buf != NULL) pty_buf_free(pss->pty_buf);
+
+  if (pss->process != NULL) {
+    ((pty_ctx_t *)pss->process->ctx)->ws_closed = true;
+    if (process_running(pss->process)) {
+      pty_pause(pss->process);
+      lwsl_notice("killing process, pid: %d\n", pss->process->pid);
+      pty_kill(pss->process, server->sig_code);
+    }
+  }
+}
+
 int callback_tty(struct lws *wsi, enum lws_callback_reasons reason, void *user, void *in, size_t len) {
   struct pss_tty *pss = (struct pss_tty *)user;
   char buf[256];
@@ -254,113 +355,56 @@ int callback_tty(struct lws *wsi, enum lws_callback_reasons reason, void *user, 
       lwsl_notice("WS   %s - %s, clients: %d\n", pss->path, pss->address, server->client_count);
       break;
 
-    case LWS_CALLBACK_SERVER_WRITEABLE:
-      if (!pss->initialized) {
-        if (pss->initial_cmd_index == sizeof(initial_cmds)) {
-          pss->initialized = true;
-          pty_resume(pss->process);
-          break;
-        }
-        if (send_initial_message(wsi, pss->initial_cmd_index) < 0) {
-          lwsl_err("failed to send initial message, index: %d\n", pss->initial_cmd_index);
-          lws_close_reason(wsi, LWS_CLOSE_STATUS_UNEXPECTED_CONDITION, NULL, 0);
-          return -1;
-        }
-        pss->initial_cmd_index++;
-        lws_callback_on_writable(wsi);
-        break;
-      }
-
-      if (pss->lws_close_status > LWS_CLOSE_STATUS_NOSTATUS) {
-        lws_close_reason(wsi, pss->lws_close_status, NULL, 0);
-        return 1;
-      }
-
-      if (pss->pty_buf != NULL) {
-        wsi_output(wsi, pss->pty_buf);
-        pty_buf_free(pss->pty_buf);
-        pss->pty_buf = NULL;
-        pty_resume(pss->process);
-      }
+    case LWS_CALLBACK_SERVER_WRITEABLE: {
+      int rc = handle_writeable(wsi, pss);
+      if (rc != 0) return rc;
       break;
+    }
 
     case LWS_CALLBACK_RECEIVE:
-      if (pss->buffer == NULL) {
-        pss->buffer = xmalloc(len);
-        pss->len = len;
-        memcpy(pss->buffer, in, len);
-      } else {
-        pss->buffer = xrealloc(pss->buffer, pss->len + len);
-        memcpy(pss->buffer + pss->len, in, len);
-        pss->len += len;
-      }
-
-      const char command = pss->buffer[0];
+      if (!receive_append(pss, wsi, in, len)) return 0;
 
       // check auth
-      if (server->credential != NULL && !pss->authenticated && command != JSON_DATA) {
+      if (server->credential != NULL && !pss->authenticated && pss->buffer[0] != JSON_DATA) {
         lwsl_warn("WS client not authenticated\n");
         return 1;
       }
 
-      // check if there are more fragmented messages
-      if (lws_remaining_packet_payload(wsi) > 0 || !lws_is_final_fragment(wsi)) {
-        return 0;
+      {
+        int rc = handle_command(pss);
+        if (rc == -1) return -1;
+        if (rc == 1) {
+          // not a common command — handle JSON_DATA (initial handshake) or warn
+          if (pss->buffer[0] == JSON_DATA) {
+            if (pss->process != NULL) goto recv_done;
+            uint16_t columns = 0;
+            uint16_t rows = 0;
+            json_object *obj = parse_window_size(pss->buffer, pss->len, &columns, &rows);
+            if (server->credential != NULL) {
+              struct json_object *o = NULL;
+              if (json_object_object_get_ex(obj, "AuthToken", &o)) {
+                const char *token = json_object_get_string(o);
+                if (token != NULL && !strcmp(token, server->credential))
+                  pss->authenticated = true;
+                else
+                  lwsl_warn("WS authentication failed with token: %s\n", token);
+              }
+              if (!pss->authenticated) {
+                json_object_put(obj);
+                lws_close_reason(wsi, LWS_CLOSE_STATUS_POLICY_VIOLATION, NULL, 0);
+                return -1;
+              }
+            }
+            json_object_put(obj);
+            if (!spawn_process(pss, columns, rows)) return 1;
+          } else {
+            lwsl_warn("ignored unknown message type: %c\n", pss->buffer[0]);
+          }
+        }
       }
 
-      switch (command) {
-        case INPUT:
-          if (!server->writable) break;
-          int err = pty_write(pss->process, pty_buf_init(pss->buffer + 1, pss->len - 1));
-          if (err) {
-            lwsl_err("uv_write: %s (%s)\n", uv_err_name(err), uv_strerror(err));
-            return -1;
-          }
-          break;
-        case RESIZE_TERMINAL:
-          if (pss->process == NULL) break;
-          json_object_put(
-              parse_window_size(pss->buffer + 1, pss->len - 1, &pss->process->columns, &pss->process->rows));
-          pty_resize(pss->process);
-          break;
-        case PAUSE:
-          pty_pause(pss->process);
-          break;
-        case RESUME:
-          pty_resume(pss->process);
-          break;
-        case JSON_DATA:
-          if (pss->process != NULL) break;
-          uint16_t columns = 0;
-          uint16_t rows = 0;
-          json_object *obj = parse_window_size(pss->buffer, pss->len, &columns, &rows);
-          if (server->credential != NULL) {
-            struct json_object *o = NULL;
-            if (json_object_object_get_ex(obj, "AuthToken", &o)) {
-              const char *token = json_object_get_string(o);
-              if (token != NULL && !strcmp(token, server->credential))
-                pss->authenticated = true;
-              else
-                lwsl_warn("WS authentication failed with token: %s\n", token);
-            }
-            if (!pss->authenticated) {
-              json_object_put(obj);
-              lws_close_reason(wsi, LWS_CLOSE_STATUS_POLICY_VIOLATION, NULL, 0);
-              return -1;
-            }
-          }
-          json_object_put(obj);
-          if (!spawn_process(pss, columns, rows)) return 1;
-          break;
-        default:
-          lwsl_warn("ignored unknown message type: %c\n", command);
-          break;
-      }
-
-      if (pss->buffer != NULL) {
-        free(pss->buffer);
-        pss->buffer = NULL;
-      }
+recv_done:
+      receive_cleanup(pss);
       break;
 
     case LWS_CALLBACK_CLOSED:
@@ -368,19 +412,10 @@ int callback_tty(struct lws *wsi, enum lws_callback_reasons reason, void *user, 
 
       server->client_count--;
       lwsl_notice("WS closed from %s, clients: %d\n", pss->address, server->client_count);
-      if (pss->buffer != NULL) free(pss->buffer);
-      if (pss->pty_buf != NULL) pty_buf_free(pss->pty_buf);
+
+      handle_close(pss);
       for (int i = 0; i < pss->argc; i++) {
         free(pss->args[i]);
-      }
-
-      if (pss->process != NULL) {
-        ((pty_ctx_t *)pss->process->ctx)->ws_closed = true;
-        if (process_running(pss->process)) {
-          pty_pause(pss->process);
-          lwsl_notice("killing process, pid: %d\n", pss->process->pid);
-          pty_kill(pss->process, server->sig_code);
-        }
       }
 
       if ((server->once || server->exit_no_conn) && server->client_count == 0) {
@@ -418,104 +453,27 @@ int callback_tty_client(struct lws *wsi, enum lws_callback_reasons reason, void 
       if (!spawn_process(pss, 80, 24)) return -1;
       break;
 
-    case LWS_CALLBACK_CLIENT_WRITEABLE:
-      if (!pss->initialized) {
-        if (pss->initial_cmd_index == sizeof(initial_cmds)) {
-          pss->initialized = true;
-          pty_resume(pss->process);
-          break;
-        }
-        if (send_initial_message(wsi, pss->initial_cmd_index) < 0) {
-          lwsl_err("failed to send initial message, index: %d\n", pss->initial_cmd_index);
-          lws_close_reason(wsi, LWS_CLOSE_STATUS_UNEXPECTED_CONDITION, NULL, 0);
-          return -1;
-        }
-        pss->initial_cmd_index++;
-        lws_callback_on_writable(wsi);
-        break;
-      }
-
-      if (pss->lws_close_status > LWS_CLOSE_STATUS_NOSTATUS) {
-        lws_close_reason(wsi, pss->lws_close_status, NULL, 0);
-        return 1;
-      }
-
-      if (pss->pty_buf != NULL) {
-        wsi_output(wsi, pss->pty_buf);
-        pty_buf_free(pss->pty_buf);
-        pss->pty_buf = NULL;
-        pty_resume(pss->process);
-      }
+    case LWS_CALLBACK_CLIENT_WRITEABLE: {
+      int rc = handle_writeable(wsi, pss);
+      if (rc != 0) return rc;
       break;
+    }
 
     case LWS_CALLBACK_CLIENT_RECEIVE:
-      if (pss->buffer == NULL) {
-        pss->buffer = xmalloc(len);
-        pss->len = len;
-        memcpy(pss->buffer, in, len);
-      } else {
-        pss->buffer = xrealloc(pss->buffer, pss->len + len);
-        memcpy(pss->buffer + pss->len, in, len);
-        pss->len += len;
-      }
-
-      if (lws_remaining_packet_payload(wsi) > 0 || !lws_is_final_fragment(wsi)) {
-        return 0;
-      }
+      if (!receive_append(pss, wsi, in, len)) return 0;
 
       {
-        const char command = pss->buffer[0];
-        switch (command) {
-          case INPUT:
-            if (!server->writable) break;
-            if (pss->process == NULL) break;
-            {
-              int err = pty_write(pss->process, pty_buf_init(pss->buffer + 1, pss->len - 1));
-              if (err) {
-                lwsl_err("uv_write: %s (%s)\n", uv_err_name(err), uv_strerror(err));
-                return -1;
-              }
-            }
-            break;
-          case RESIZE_TERMINAL:
-            if (pss->process == NULL) break;
-            json_object_put(
-                parse_window_size(pss->buffer + 1, pss->len - 1, &pss->process->columns, &pss->process->rows));
-            pty_resize(pss->process);
-            break;
-          case PAUSE:
-            if (pss->process != NULL) pty_pause(pss->process);
-            break;
-          case RESUME:
-            if (pss->process != NULL) pty_resume(pss->process);
-            break;
-          default:
-            lwsl_warn("ignored unknown message type: %c\n", command);
-            break;
-        }
+        int rc = handle_command(pss);
+        if (rc == -1) return -1;
+        if (rc == 1) lwsl_warn("ignored unknown message type: %c\n", pss->buffer[0]);
       }
 
-      if (pss->buffer != NULL) {
-        free(pss->buffer);
-        pss->buffer = NULL;
-      }
+      receive_cleanup(pss);
       break;
 
     case LWS_CALLBACK_CLOSED:
       lwsl_notice("WS client connection closed\n");
-
-      if (pss->buffer != NULL) free(pss->buffer);
-      if (pss->pty_buf != NULL) pty_buf_free(pss->pty_buf);
-
-      if (pss->process != NULL) {
-        ((pty_ctx_t *)pss->process->ctx)->ws_closed = true;
-        if (process_running(pss->process)) {
-          pty_pause(pss->process);
-          lwsl_notice("killing process, pid: %d\n", pss->process->pid);
-          pty_kill(pss->process, server->sig_code);
-        }
-      }
-
+      handle_close(pss);
       force_exit = true;
       lws_cancel_service(context);
       uv_stop(server->loop);

--- a/src/server.c
+++ b/src/server.c
@@ -25,11 +25,16 @@ struct endpoints endpoints = {"/ws", "/", "/token", ""};
 
 extern int callback_http(struct lws *wsi, enum lws_callback_reasons reason, void *user, void *in, size_t len);
 extern int callback_tty(struct lws *wsi, enum lws_callback_reasons reason, void *user, void *in, size_t len);
+extern int callback_tty_client(struct lws *wsi, enum lws_callback_reasons reason, void *user, void *in, size_t len);
 
 // websocket protocols
 static const struct lws_protocols protocols[] = {{"http-only", callback_http, sizeof(struct pss_http), 0},
                                                  {"tty", callback_tty, sizeof(struct pss_tty), 0},
                                                  {NULL, NULL, 0, 0}};
+
+// websocket protocols for client (outbound) mode
+static const struct lws_protocols client_protocols[] = {{"tty", callback_tty_client, sizeof(struct pss_tty), 0},
+                                                        {NULL, NULL, 0, 0}};
 
 #ifndef LWS_WITHOUT_EXTENSIONS
 // websocket extensions
@@ -81,6 +86,7 @@ static const struct option options[] = {{"port", required_argument, NULL, 'p'},
                                         {"once", no_argument, NULL, 'o'},
                                         {"exit-no-conn", no_argument, NULL, 'q'},
                                         {"browser", no_argument, NULL, 'B'},
+                                        {"connect", required_argument, NULL, 256},
                                         {"debug", required_argument, NULL, 'd'},
                                         {"version", no_argument, NULL, 'v'},
                                         {"help", no_argument, NULL, 'h'},
@@ -128,6 +134,8 @@ static void print_help() {
           "    -K, --ssl-key           SSL key file path\n"
           "    -A, --ssl-ca            SSL CA file path for client certificate verification\n"
 #endif
+          "        --connect            Connect to a remote WebSocket URL instead of listening (client mode,\n"
+          "                               eg: ws://host:port/path or wss://host:port/path)\n"
           "    -d, --debug             Set log level (default: 7)\n"
           "    -v, --version           Print the version and exit\n"
           "    -h, --help              Print this text and exit\n\n"
@@ -150,6 +158,7 @@ static void print_config() {
     lwsl_notice("  token    : %s\n", endpoints.token);
     lwsl_notice("  websocket: %s\n", endpoints.ws);
   }
+  if (server->connect_url != NULL) lwsl_notice("  connect URL: %s\n", server->connect_url);
   if (server->auth_header != NULL) lwsl_notice("  auth header: %s\n", server->auth_header);
   if (server->check_origin) lwsl_notice("  check origin: true\n");
   if (server->url_arg) lwsl_notice("  allow url arg: true\n");
@@ -210,6 +219,7 @@ static void server_free(struct server *ts) {
   if (ts->auth_header != NULL) free(ts->auth_header);
   if (ts->index != NULL) free(ts->index);
   if (ts->cwd != NULL) free(ts->cwd);
+  if (ts->connect_url != NULL) free(ts->connect_url);
   free(ts->command);
   free(ts->prefs_json);
 
@@ -499,6 +509,9 @@ int main(int argc, char **argv) {
         strncpy(server->terminal_type, optarg, sizeof(server->terminal_type) - 1);
         server->terminal_type[sizeof(server->terminal_type) - 1] = '\0';
         break;
+      case 256:
+        server->connect_url = strdup(optarg);
+        break;
       case '?':
         break;
       case 't':
@@ -590,7 +603,14 @@ int main(int argc, char **argv) {
   void *foreign_loops[1];
   foreign_loops[0] = server->loop;
   info.foreign_loops = foreign_loops;
-  info.options |= LWS_SERVER_OPTION_EXPLICIT_VHOSTS;
+
+  if (server->connect_url != NULL) {
+    // Client mode: no listening, use client protocols
+    info.port = CONTEXT_PORT_NO_LISTEN;
+    info.protocols = client_protocols;
+  } else {
+    info.options |= LWS_SERVER_OPTION_EXPLICIT_VHOSTS;
+  }
 
   context = lws_create_context(&info);
   if (context == NULL) {
@@ -598,18 +618,58 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  struct lws_vhost *vhost = lws_create_vhost(context, &info);
-  if (vhost == NULL) {
-    lwsl_err("libwebsockets vhost creation failed\n");
-    return 1;
-  }
-  int port = lws_get_vhost_listen_port(vhost);
-  lwsl_notice(" Listening on port: %d\n", port);
+  if (server->connect_url != NULL) {
+    // Client mode: parse URL and connect outbound
+    char *url_copy = strdup(server->connect_url);
+    const char *prot, *address, *path;
+    int port;
+    if (lws_parse_uri(url_copy, &prot, &address, &port, &path)) {
+      lwsl_err("failed to parse connect URL: %s\n", server->connect_url);
+      free(url_copy);
+      return 1;
+    }
 
-  if (browser) {
-    char url[30];
-    snprintf(url, sizeof(url), "%s://localhost:%d", ssl ? "https" : "http", port);
-    open_uri(url);
+    char full_path[256];
+    snprintf(full_path, sizeof(full_path), "/%s", path);
+
+    struct lws_client_connect_info ccinfo;
+    memset(&ccinfo, 0, sizeof(ccinfo));
+    ccinfo.context = context;
+    ccinfo.address = address;
+    ccinfo.port = port;
+    ccinfo.path = full_path;
+    ccinfo.host = address;
+    ccinfo.origin = address;
+    ccinfo.protocol = "tty";
+
+    bool use_ssl = (strcmp(prot, "wss") == 0 || strcmp(prot, "https") == 0);
+    if (use_ssl) {
+      ccinfo.ssl_connection = LCCSCF_USE_SSL;
+    }
+
+    if (lws_client_connect_via_info(&ccinfo) == NULL) {
+      lwsl_err("failed to initiate connection to %s\n", server->connect_url);
+      free(url_copy);
+      return 1;
+    }
+
+    lwsl_notice("connecting to %s\n", server->connect_url);
+    free(url_copy);
+  } else {
+    // Server mode: create listening vhost
+    struct lws_vhost *vhost = lws_create_vhost(context, &info);
+    if (vhost == NULL) {
+      lwsl_err("libwebsockets vhost creation failed\n");
+      return 1;
+    }
+    int port = lws_get_vhost_listen_port(vhost);
+    lwsl_notice(" Listening on port: %d\n", port);
+
+    if (browser) {
+      char url[30];
+      snprintf(url, sizeof(url), "%s://localhost:%d", ssl ? "https" : "http", port);
+      open_uri(url);
+    }
   }
 
 #define sig_count 2

--- a/src/server.h
+++ b/src/server.h
@@ -81,6 +81,7 @@ struct server {
   bool exit_no_conn;       // whether exit on all clients disconnection
   char socket_path[255];   // UNIX domain socket path
   char terminal_type[30];  // terminal type to report
+  char *connect_url;       // outbound websocket URL (client mode)
 
   uv_loop_t *loop;         // the libuv event loop
 };

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "test",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "ws": "^8.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "ws": "^8.0.0"
+  }
+}

--- a/test/test-outbound.js
+++ b/test/test-outbound.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+//
+// End-to-end test for ttyd outbound websocket (--connect) mode.
+//
+// Starts a WebSocket server, launches ttyd in client mode against it,
+// verifies bidirectional communication, then exits with 0 on success.
+//
+// Usage:
+//   npm install ws   # one-time
+//   node test/test-outbound.js [path-to-ttyd-binary]
+//
+
+const { WebSocketServer } = require('ws');
+const { spawn } = require('child_process');
+const path = require('path');
+
+const TTYD = process.argv[2] || path.join(__dirname, '..', 'build', 'ttyd');
+const PORT = 0; // let the OS pick a free port
+
+function startServer() {
+  return new Promise((resolve) => {
+    const wss = new WebSocketServer({
+      port: PORT,
+      handleProtocols: (protocols) => (protocols.has('tty') ? 'tty' : false),
+    });
+
+    wss.on('listening', () => {
+      const port = wss.address().port;
+      resolve({ wss, port });
+    });
+  });
+}
+
+function runTest(wss, port) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('test timed out after 10s'));
+    }, 10000);
+
+    const results = {
+      connected: false,
+      gotTitle: false,
+      gotPrefs: false,
+      gotOutput: false,
+      inputEchoed: false,
+      cleanClose: false,
+    };
+
+    wss.on('connection', (ws) => {
+      results.connected = true;
+      let sentInput = false;
+
+      ws.on('message', (data) => {
+        const buf = Buffer.from(data);
+        const cmd = String.fromCharCode(buf[0]);
+        const payload = buf.slice(1).toString();
+
+        switch (cmd) {
+          case '1': // SET_WINDOW_TITLE
+            results.gotTitle = true;
+            break;
+          case '2': // SET_PREFERENCES
+            results.gotPrefs = true;
+            break;
+          case '0': // OUTPUT
+            results.gotOutput = true;
+            if (payload.includes('OUTBOUND_TEST_OK')) {
+              results.inputEchoed = true;
+            }
+
+            // Once we get some output, send a command and then exit
+            if (!sentInput) {
+              sentInput = true;
+              const input = 'echo OUTBOUND_TEST_OK\n';
+              const msg = Buffer.alloc(1 + input.length);
+              msg[0] = '0'.charCodeAt(0); // INPUT
+              msg.write(input, 1);
+              ws.send(msg);
+
+              setTimeout(() => {
+                const exitMsg = Buffer.alloc(1 + 5);
+                exitMsg[0] = '0'.charCodeAt(0);
+                exitMsg.write('exit\n', 1);
+                ws.send(exitMsg);
+              }, 500);
+            }
+            break;
+        }
+      });
+
+      ws.on('close', (code) => {
+        results.cleanClose = code === 1000;
+        clearTimeout(timeout);
+        resolve(results);
+      });
+    });
+
+    // Launch ttyd in client mode
+    const ttyd = spawn(TTYD, ['--connect', `ws://localhost:${port}`, '-W', 'bash'], {
+      stdio: 'ignore',
+    });
+
+    ttyd.on('error', (err) => {
+      clearTimeout(timeout);
+      reject(new Error(`failed to spawn ttyd: ${err.message}`));
+    });
+  });
+}
+
+async function main() {
+  const { wss, port } = await startServer();
+  console.log(`test server listening on port ${port}`);
+
+  try {
+    const results = await runTest(wss, port);
+
+    console.log('');
+    const checks = [
+      ['Client connected', results.connected],
+      ['SET_WINDOW_TITLE received', results.gotTitle],
+      ['SET_PREFERENCES received', results.gotPrefs],
+      ['OUTPUT received', results.gotOutput],
+      ['Remote input echoed back', results.inputEchoed],
+      ['Clean disconnect (code 1000)', results.cleanClose],
+    ];
+
+    let allPass = true;
+    for (const [name, pass] of checks) {
+      console.log(`  ${pass ? 'PASS' : 'FAIL'}  ${name}`);
+      if (!pass) allPass = false;
+    }
+
+    console.log(`\n${allPass ? 'ALL PASS' : 'SOME FAILED'}`);
+    process.exit(allPass ? 0 : 1);
+  } finally {
+    wss.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds `--connect <ws://url>` option that puts ttyd in **client mode**: instead of listening for incoming browser connections, ttyd connects outbound to a remote WebSocket server and bridges the local PTY to it
- The remote endpoint receives terminal output (`OUTPUT`) and can send input (`INPUT`, `RESIZE_TERMINAL`, `PAUSE`, `RESUME`) using the same binary protocol
- Supports both `ws://` and `wss://` (TLS) URLs

## Usage

```sh
# Connect to a remote WebSocket server, sharing a bash session
ttyd --connect ws://relay.example.com:8080/ws -W bash

# With TLS
ttyd --connect wss://relay.example.com/ws -W bash
```

## Use cases

- **NAT traversal**: ttyd connects outbound to a relay server when it can't listen on a public port
- **Service integration**: bridge a local terminal to a remote service that accepts WebSocket connections

## Changes

- `src/server.h`: Added `connect_url` field to `server` struct
- `src/server.c`: Added `--connect` CLI option, client protocol array, and client-mode branching in `main()` (skips vhost creation, uses `lws_client_connect_via_info()` instead)
- `src/protocol.c`: Extracted shared helpers (`handle_writeable`, `receive_append`, `handle_command`, `handle_close`) used by both server and client callbacks. Added `callback_tty_client()` for client-mode connections
- `test/test-outbound.js`: End-to-end test — starts a WS server, connects ttyd in client mode, verifies bidirectional OUTPUT/INPUT and clean disconnect

## Test plan

- [x] `ttyd --help` shows the new `--connect` option
- [x] Server mode (no `--connect`) is unchanged
- [x] Client mode against a compatible WebSocket server (OUTPUT, SET_WINDOW_TITLE, SET_PREFERENCES sent)
- [x] Remote input received and executed by local PTY
- [x] Connection error handling (unreachable host, refused connection)
- [x] Clean disconnect (code 1000) on process exit
- [ ] `wss://` with TLS-enabled endpoint