### PR TITLE
Bump ubuntu base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 ARG TARGETARCH
 


### PR DESCRIPTION
Bumps the ubuntu base image from 24.04 to 26.04.

https://documentation.ubuntu.com/release-notes/26.04/

Ubuntu 26.04 LTS is the latest Long Term Support version.