### PR TITLE
fix(security): reject plaintext upgrades when SSL is enabled

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -97,6 +97,13 @@ int callback_http(struct lws *wsi, enum lws_callback_reasons reason, void *user,
   bool done = false;
 
   switch (reason) {
+    case LWS_CALLBACK_HTTP_CONFIRM_UPGRADE:
+      if (server->ssl && !lws_is_ssl(wsi)) {
+        lwsl_warn("refuse HTTP upgrade over non-SSL connection while SSL is enabled.\n");
+        return -1;
+      }
+      break;
+
     case LWS_CALLBACK_HTTP:
       access_log(wsi, (const char *)in);
       snprintf(pss->path, sizeof(pss->path), "%s", (const char *)in);

--- a/src/server.c
+++ b/src/server.c
@@ -563,6 +563,7 @@ int main(int argc, char **argv) {
 
 #if defined(LWS_OPENSSL_SUPPORT) || defined(LWS_WITH_TLS)
   if (ssl) {
+    server->ssl = true;
     info.ssl_cert_filepath = cert_path;
     info.ssl_private_key_filepath = key_path;
 #ifndef LWS_WITH_MBEDTLS

--- a/src/server.h
+++ b/src/server.h
@@ -76,6 +76,7 @@ struct server {
   bool url_arg;            // allow client to send cli arguments in URL
   bool writable;           // whether clients to write to the TTY
   bool check_origin;       // whether allow websocket connection from different origin
+  bool ssl;                // whether SSL is enabled
   int max_clients;         // maximum clients to support
   bool once;               // whether accept only one client and exit on disconnection
   bool exit_no_conn;       // whether exit on all clients disconnection


### PR DESCRIPTION
## Summary
- reject non-TLS HTTP upgrade requests when SSL is enabled
- keep existing HTTP-to-HTTPS redirect behavior for normal HTTP requests
- prevent plaintext WebSocket upgrades from bypassing SSL enforcement

## Security impact
When ttyd is started with SSL enabled, libwebsockets is configured to allow plaintext HTTP on the SSL port and redirect it to HTTPS. Normal HTTP requests are redirected, but plaintext WebSocket upgrade requests can still be accepted and return `101 Switching Protocols`.

This means `/ws` can be reached over a non-TLS connection even when SSL is enabled. If mTLS is configured with `--ssl-ca`, client certificate verification only happens during the TLS handshake, so this plaintext upgrade path can bypass the expected client certificate check.

This patch rejects all non-TLS HTTP upgrade requests when SSL is enabled.

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- verified `http://127.0.0.1:<port>/` returns `301 Redirect`
- verified plaintext WebSocket upgrade to `/ws` no longer returns `101 Switching Protocols`
- verified `https://127.0.0.1:<port>/token` still returns `200 OK`